### PR TITLE
fix: AIFW-21696: ValidateMCPServersRequest allows omitting required fields

### DIFF
--- a/aidefense/mcpscan/models.py
+++ b/aidefense/mcpscan/models.py
@@ -894,11 +894,11 @@ class ValidateMCPServersRequest(AIDefenseModel):
 
     Args:
         urls: List of MCP server URLs to validate with the same transport_type and auth_config.
-        transport_type: Optional transport type to validate server connectivity.
+        transport_type: Transport type to validate server connectivity.
         auth_config: Optional authentication configuration to validate server connectivity.
     """
-    urls: List[str] = Field(None, description="List of MCP server URLs to validate")
-    transport_type: TransportType = Field(None, alias="transportType", description="Transport type for server connection (optional)")
+    urls: List[str] = Field(..., description="List of MCP server URLs to validate")
+    transport_type: TransportType = Field(..., alias="transportType", description="Transport type for server connection")
     auth_config: Optional[AuthConfig] = Field(None, alias="authConfig", description="Authentication configuration (optional)")
 
 

--- a/aidefense/tests/test_mcp_scan_base.py
+++ b/aidefense/tests/test_mcp_scan_base.py
@@ -16,6 +16,7 @@
 
 import pytest
 from unittest.mock import MagicMock, call
+from pydantic import ValidationError
 
 from aidefense.mcpscan.mcp_scan_base import MCPScan
 from aidefense.mcpscan.models import (
@@ -2163,6 +2164,19 @@ class TestRegisteredServerScans:
             "Verify the endpoint is reachable"
         ]
         assert response.invalid_urls[0].error_info.occurred_at is not None
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"transport_type": TransportType.SSE},
+            {"urls": ["https://valid.example.com/sse"]},
+            {},
+        ],
+    )
+    def test_validate_servers_request_missing_required_fields_raises_validation_error(self, payload):
+        """ValidateMCPServersRequest should fail when required fields are omitted."""
+        with pytest.raises(ValidationError):
+            ValidateMCPServersRequest(**payload)
 
     def test_server_scan_methods_propagate_api_errors(self, mcp_scan):
         """Test new MCPScan methods propagate API errors unchanged."""


### PR DESCRIPTION

## Summary

Fixes AIFW-21696 by enforcing required validation in MCP server validation request models.

This change makes missing validation inputs fail fast at model validation time, so incomplete payloads are rejected before request execution.

## Changes

- Made `ValidateMCPServersRequest.urls` required (changed from optional to required).
- Made `ValidateMCPServersRequest.transport_type` required (changed from optional to required).
- Updated `ValidateMCPServersRequest` field descriptions to reflect required transport type.
- Added negative validation tests:
	- `ValidateMCPServersRequest` without `urls` raises `ValidationError`.
	- `ValidateMCPServersRequest` without `transport_type` raises `ValidationError`.
	- `ValidateMCPServersRequest` without both required fields raises `ValidationError`.

## Test Plan

- [x] Targeted unit tests pass: `pytest -q aidefense/tests/test_mcp_scan_base.py -k missing_required_fields`.
- [x] Verified result: `3 passed, 84 deselected`.
- [x] Validation path confirmed for missing `urls`.
- [x] Validation path confirmed for missing `transport_type`.
- [x] Validation path confirmed for payloads missing both required fields.

## Compatibility Notes

- Behavioral tightening: client code must now provide both `urls` and `transport_type` when building MCP server validation requests.
- Expected impact: integrations that relied on omitted required fields will now fail validation and should be updated accordingly.
