### PR TITLE
fix: AIFW-21695: Missing API coverage in MCP Scan module

### DIFF
--- a/aidefense/mcpscan/__init__.py
+++ b/aidefense/mcpscan/__init__.py
@@ -92,6 +92,11 @@ from .models import (
     # ListMCPServers Request/Response Models
     ListMCPServersRequest,
     ListMCPServersResponse,
+    # MCP Server Stats Request/Response Models
+    GetMCPServerStatsResponse,
+    AttackTechnique,
+    ScanCoverage,
+    MCPServerStats,
     # UpdateAuthConfig Request/Response Models
     UpdateAuthConfigRequest,
     UpdateAuthConfigResponse,

--- a/aidefense/mcpscan/mcp_scan_base.py
+++ b/aidefense/mcpscan/mcp_scan_base.py
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
 from typing import List, Optional
 
 from aidefense.config import Config
@@ -22,6 +23,7 @@ from aidefense.management.base_client import BaseClient
 from aidefense.request_handler import HttpMethod
 from aidefense.mcpscan.models import (
     GetMCPServerScanReportRequest,
+    ListServerType,
     StartMCPServerScanRequest,
     StartMCPServerScanResponse,
     GetMCPScanStatusResponse,
@@ -44,6 +46,7 @@ from aidefense.mcpscan.models import (
     GetMCPServerScanReportResponse,
     ValidateMCPServersRequest,
     ValidateMCPServersResponse,
+    GetMCPServerStatsResponse,
 )
 from aidefense.mcpscan.routes import (
     mcp_scan_start,
@@ -59,6 +62,7 @@ from aidefense.mcpscan.routes import (
     mcp_server_scan,
     mcp_server_scan_report,
     mcp_servers_validate,
+    mcp_servers_stats,
 )
 
 
@@ -691,6 +695,8 @@ class MCPScan(BaseClient):
             registry_id: Optional[str] = None,
             sort_by: Optional[ServersSortBy] = None,
             sort_order: Optional[SortOrder] = None,
+            scan_date: Optional[datetime] = None,
+            server_types: Optional[List[ListServerType]] = None,
     ) -> ListMCPServersResponse:
         """
         List registered MCP servers with optional filtering.
@@ -708,7 +714,8 @@ class MCPScan(BaseClient):
                 Use TransportType enum values.
             severity (List[SeverityLevel], optional): Filter by severity level(s).
                 Use SeverityLevel enum values.
-
+            scan_date (datetime, optional): Filter by last scan date.
+            server_types (List[ListServerType], optional): Filter by server type(s). Use ListServerType enum values.
         Returns:
             ListMCPServersResponse: Response object containing:
                 - mcp_servers: MCPServers object with:
@@ -769,14 +776,41 @@ class MCPScan(BaseClient):
             request.sort_by = sort_by
         if sort_order:
             request.sort_order = sort_order
+        if scan_date:
+            request.scan_date = scan_date
+        if server_types:
+            request.server_types = server_types
 
         res = self.make_request(
             method=HttpMethod.GET,
             path=mcp_servers_list(),
             params=request.to_params(),
         )
-        result = ListMCPServersResponse.parse_obj(res)
+        result = ListMCPServersResponse.model_validate(res)
         self.config.logger.debug(f"Listed MCP servers: {result}")
+        return result
+
+    def server_stats(
+            self,
+        ) -> GetMCPServerStatsResponse:
+        """Get aggregated stats for MCP servers.
+
+        This method retrieves aggregate server statistics from the MCP registry.
+
+        Returns:
+            GetMCPServerStatsResponse: Response object containing aggregated stats.
+
+        Raises:
+            ApiError: If the API returns an error response.
+            SDKError: For other SDK-related errors.
+        """
+
+        res = self.make_request(
+            method=HttpMethod.GET,
+            path=mcp_servers_stats(),
+        )
+        result = GetMCPServerStatsResponse.model_validate(res)
+        self.config.logger.debug(f"Retrieved MCP server stats: {result}")
         return result
 
     def update_auth_config(

--- a/aidefense/mcpscan/models.py
+++ b/aidefense/mcpscan/models.py
@@ -60,6 +60,7 @@ class AnalyzerType(str, Enum):
     YARA = "YARA"
     LLM = "LLM"
     AIGRPC = "AIGRPC"
+    BEHAVIORAL = "BEHAVIORAL"
 
 
 class SeverityLevel(str, Enum):
@@ -69,6 +70,7 @@ class SeverityLevel(str, Enum):
     LOW = "LOW"
     MEDIUM = "MEDIUM"
     HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
 
 class ThreatSeverityLevel(str, Enum):
     """Severity levels for threats."""
@@ -119,6 +121,12 @@ class ListServerType(str, Enum):
     MCP_SERVER_NONE = "MCP_SERVER_NONE"
     MCP_SERVER_CODE = "MCP_SERVER_CODE"
     MCP_SERVER_REMOTE = "MCP_SERVER_REMOTE"
+
+class RegistrationMethod(str, Enum):
+    """Method used to register the MCP server."""
+    MCP_SERVER_REGISTRATION_METHOD_UNSPECIFIED = "MCP_SERVER_REGISTRATION_METHOD_UNSPECIFIED"
+    MCP_SERVER_REGISTRATION_METHOD_MANUAL = "MCP_SERVER_REGISTRATION_METHOD_MANUAL"
+    MCP_SERVER_REGISTRATION_METHOD_REGISTRY = "MCP_SERVER_REGISTRATION_METHOD_REGISTRY"
 
 def restore_enum_wrapper(cls, values):
     """Helper to restore enum values from string representations."""
@@ -247,6 +255,7 @@ class Tool(AIDefenseModel):
         input_schema: Input schema of the tool.
         output_schema: Optional output schema of the tool.
         annotations: Optional annotations map.
+        rawResponse: Optional raw response from the capability call (for debugging/advanced use).
     """
     id: str = Field(..., description="Tool identifier (UUID)")
     name: str = Field(..., description="Tool name")
@@ -255,6 +264,7 @@ class Tool(AIDefenseModel):
     input_schema: Optional[ToolInputSchema] = Field(None, description="Input schema")
     output_schema: Optional[ToolOutputSchema] = Field(None, description="Output schema")
     annotations: Dict[str, str] = Field(default_factory=dict, description="Annotations")
+    rawResponse: Optional[dict] = Field(None, description="Raw response from capability call")
 
 
 class PromptInputSchema(AIDefenseModel):
@@ -264,10 +274,12 @@ class PromptInputSchema(AIDefenseModel):
         name: Name of the prompt template.
         description: Description of what the prompt does.
         required: Whether this argument is mandatory.
+        rawResponse: Optional raw response from the capability call (for debugging/advanced use).
     """
     name: str = Field(..., description="Prompt template name")
     description: str = Field(default="", description="Prompt description")
     required: bool = Field(default=False, description="Whether required")
+    rawResponse: Optional[dict] = Field(None, alias="rawResponse", description="Raw response from capability call for debugging/advanced use")
 
 
 class Prompt(AIDefenseModel):
@@ -297,6 +309,7 @@ class Resource(AIDefenseModel):
         title: Optional title of the resource.
         uri: URI to access the resource.
         mime_type: MIME type of the resource content.
+        rawResponse: Optional raw response from the capability call (for debugging/advanced use).
     """
     id: str = Field(..., description="Resource identifier (UUID)")
     name: str = Field(..., description="Resource name")
@@ -304,6 +317,7 @@ class Resource(AIDefenseModel):
     title: Optional[str] = Field(None, description="Resource title")
     uri: str = Field(default="", description="Resource URI")
     mime_type: str = Field(default="", description="MIME type")
+    rawResponse: Optional[dict] = Field(None, description="Raw response from capability call for debugging/advanced use")
 
 
 class Capability(AIDefenseModel):
@@ -840,6 +854,7 @@ class GetMCPServerScanReportRequest(AIDefenseModel):
     Args:
         server_id: The unique identifier of the MCP server.
         offset: Offset to fetch objects from.
+        limit: Maximum number of objects to fetch.
         filter_options: Filter options applied to the report.
     """
     server_id: Optional[str] = Field(
@@ -850,6 +865,10 @@ class GetMCPServerScanReportRequest(AIDefenseModel):
     offset: Optional[int] = Field(
         None,
         description="Offset to fetch objects from"
+    )
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of objects to fetch",
     )
     filter_options: FilterOptions = Field(
         None,
@@ -901,6 +920,19 @@ class ValidateMCPServersRequest(AIDefenseModel):
     transport_type: TransportType = Field(None, alias="transportType", description="Transport type for server connection (optional)")
     auth_config: Optional[AuthConfig] = Field(None, alias="authConfig", description="Authentication configuration (optional)")
 
+class ContextObjectType(str, Enum):
+    """Type of context object for MCP server scan results."""
+    CONTEXT_OBJECT_TYPE_UNSPECIFIED = "CONTEXT_OBJECT_TYPE_UNSPECIFIED"
+    MCP_SERVER = "MCP_SERVER"
+    MCP_REGISTRY = "MCP_REGISTRY"
+    MCP_SCAN_WORKFLOW = "MCP_SCAN_WORKFLOW"
+
+class ContextObject(AIDefenseModel):
+    """ContextObject represents an object in our stack, such as a capability, technique, or threat."""
+    id: str = Field(..., description="Unique identifier for the object")
+    name: Optional[str] = Field(None, description="Name of the object if applicable")
+    object_type: Optional[ContextObjectType] = Field(None, alias="objectType", description="Type of the object (e.g., capability, technique, threat)")
+
 
 class ErrorInfo(AIDefenseModel):
     """Error information for failed scans.
@@ -910,11 +942,16 @@ class ErrorInfo(AIDefenseModel):
         error_message: Raw error message (may not be exposed to end users).
         remediation_tips: List of remediation steps or tips to resolve the issue.
         occurred_at: Timestamp when the error occurred.
+        context_object: Optional object related to the error (e.g., capability or technique that caused the error).
+        metadata: Additional arbitrary metadata (e.g., internal trace ids, error context).
     """
     message: str = Field(..., min_length=1, max_length=32768, description="Human-readable error summary")
     error_message: Optional[str] = Field(None, max_length=32768, description="Raw error message")
     remediation_tips: List[str] = Field(default_factory=list, description="Remediation steps or tips")
     occurred_at: Optional[datetime] = Field(None, description="When the error occurred")
+    context_object: Optional[ContextObject] = Field(None, alias="contextObject", description="Context object related to the error")
+    metadata: Optional[Dict[str, str]] = Field(default_factory=dict, description="Additional arbitrary metadata (e.g., internal trace ids, error context)")
+
 
 
 class InvalidURLInfo(AIDefenseModel):
@@ -1384,6 +1421,8 @@ class MCPServer(AIDefenseModel):
     type: Optional[List[ListServerType]] = Field(None, alias="type", description="Server type")
     threat_summary: Optional[ScanThreatSummary] = Field(None, alias="threatSummary", description="Summary of threats found during an MCP server scan")
     last_scanned_at: Optional[datetime] = Field(None, alias="lastScannedAt", description="Time of last scan")
+    technique_names: Optional[List[str]] = Field(None, alias="techniqueNames", description="List of technique names found during an MCP server scan")
+    registration_method: Optional[RegistrationMethod] = Field(None, alias="registrationMethod", description="Method used to register the MCP server")
 
     @model_validator(mode='before')
     @classmethod
@@ -1439,9 +1478,11 @@ class ListMCPServersRequest(AIDefenseModel):
         transport_type: Filter by transport type(s).
         severity: Filter by severity level(s).
         creation_date: Filter by creation date.
-    registry_id: Registry id.
+        registry_id: Registry id.
         sort_by: Sort by given parameter.
         sort_order: Sort order.
+        scan_date: Filter by last scan date.
+        server_types: Filter by server type (Remote/Code).
     """
     limit: int = Field(default=25, description="Maximum results to return")
     offset: int = Field(default=0, description="Pagination offset")
@@ -1453,6 +1494,8 @@ class ListMCPServersRequest(AIDefenseModel):
     registry_id: Optional[str] = Field(None, description="Registry id")
     sort_by: Optional[ServersSortBy] = Field(None, description="Sort by given parameter")
     sort_order: Optional[SortOrder] = Field(None, description="Sort order")
+    scan_date: Optional[datetime] = Field(None, alias="scanDate", description="Filter by last scan date")
+    server_types: Optional[List[ListServerType]] = Field(None, alias="serverTypes", description="Filter by server type (Remote/Code)")
 
 
 class ListMCPServersResponse(AIDefenseModel):
@@ -1462,6 +1505,60 @@ class ListMCPServersResponse(AIDefenseModel):
         mcp_servers: List of MCP servers with pagination information.
     """
     mcp_servers: Optional[MCPServers] = Field(None, alias="mcpServers", description="MCP servers list")
+
+
+# --------------------
+# MCP Server Stats Request/Response Models
+# --------------------
+
+class AttackTechnique(AIDefenseModel):
+    """Attack technique with occurrence count.
+
+    Args:
+        name: Name of the attack technique.
+        count: Number of occurrences of this attack technique.
+    """
+    name: str = Field(default="", description="Attack technique name")
+    count: int = Field(default=0, description="Attack technique count")
+
+
+class ScanCoverage(AIDefenseModel):
+    """Scan coverage statistics for MCP servers.
+
+    Args:
+        completed_count: Number of completed scans.
+        in_progress_count: Number of scans in progress.
+        failed_count: Number of failed scans.
+    """
+    completed_count: int = Field(default=0, alias="completedCount", description="Completed scans count")
+    in_progress_count: int = Field(default=0, alias="inProgressCount", description="In-progress scans count")
+    failed_count: int = Field(default=0, alias="failedCount", description="Failed scans count")
+
+
+class MCPServerStats(AIDefenseModel):
+    """Aggregated MCP server statistics.
+
+    Args:
+        risk_distribution: Threat severity distribution.
+        top_attack_techniques: Top attack techniques by count.
+        scan_coverage: Scan coverage details.
+    """
+    risk_distribution: Optional[ScanThreatSummary] = Field(None, alias="riskDistribution", description="Risk distribution")
+    top_attack_techniques: List[AttackTechnique] = Field(
+        default_factory=list,
+        alias="topAttackTechniques",
+        description="Top attack techniques"
+    )
+    scan_coverage: Optional[ScanCoverage] = Field(None, alias="scanCoverage", description="Scan coverage")
+
+
+class GetMCPServerStatsResponse(AIDefenseModel):
+    """Response message for MCP server statistics.
+
+    Args:
+        stats: Aggregated MCP server statistics.
+    """
+    stats: Optional[MCPServerStats] = Field(None, description="MCP server statistics")
 
 
 # --------------------

--- a/aidefense/mcpscan/routes.py
+++ b/aidefense/mcpscan/routes.py
@@ -48,6 +48,11 @@ def mcp_servers_list() -> str:
     return MCP_SERVERS
 
 
+def mcp_servers_stats() -> str:
+    """Route for getting MCP server stats."""
+    return f"{MCP_SERVERS}:stats"
+
+
 def mcp_server_update_auth_config(server_id: str) -> str:
     """Route for updating MCP server authentication configuration."""
     return f"{MCP_SERVERS}/{server_id}/auth"

--- a/aidefense/tests/test_mcp_scan_base.py
+++ b/aidefense/tests/test_mcp_scan_base.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, call
 
 from aidefense.mcpscan.mcp_scan_base import MCPScan
@@ -32,6 +33,7 @@ from aidefense.mcpscan.models import (
     GetMCPServerResponse,
     ListMCPServersRequest,
     ListMCPServersResponse,
+    GetMCPServerStatsResponse,
     UpdateAuthConfigRequest,
     UpdateAuthConfigResponse,
     CapabilityType,
@@ -51,6 +53,21 @@ from aidefense.mcpscan.models import (
     ThreatSeverityLevel,
     ValidateMCPServersRequest,
     ValidateMCPServersResponse,
+    AnalyzerType,
+    RegistrationMethod,
+    ContextObjectType,
+    ListServerType,
+    ContextObject,
+    ErrorInfo,
+    AttackTechnique,
+    ScanCoverage,
+    MCPServerStats,
+    Tool,
+    PromptInputSchema,
+    Resource,
+    MCPServer,
+    ThreatDetails,
+    ScanThreatSummary,
 )
 from aidefense.config import Config
 from aidefense.request_handler import HttpMethod
@@ -475,6 +492,41 @@ class TestGetScanStatus:
 
         assert "Scan not found" in str(excinfo.value)
 
+    def test_get_scan_status_failed_with_error_context(self, mcp_scan):
+        """Test FAILED scan status parses error_info with context_object and metadata."""
+        mock_response = {
+            "scan_id": "scan-200",
+            "name": "Failed With Context",
+            "status": "FAILED",
+            "created_at": "2026-01-15T10:00:00Z",
+            "error_info": {
+                "message": "Capability scan failed",
+                "errorMessage": "Internal server error",
+                "remediation_tips": ["Retry the scan", "Contact support"],
+                "contextObject": {
+                    "id": "cap-456",
+                    "name": "Query Tool",
+                    "objectType": "MCP_SERVER",
+                },
+                "metadata": {
+                    "error_code": "E500",
+                    "service": "scan-engine",
+                },
+            },
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.get_scan_status("scan-200")
+
+        assert result.status == MCPScanStatus.FAILED
+        assert result.error_info is not None
+        assert result.error_info.context_object is not None
+        assert result.error_info.context_object.id == "cap-456"
+        assert result.error_info.context_object.name == "Query Tool"
+        assert result.error_info.metadata["error_code"] == "E500"
+        assert result.error_info.metadata["service"] == "scan-engine"
+        assert len(result.error_info.remediation_tips) == 2
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestRegisterServer
@@ -857,6 +909,66 @@ class TestGetServerCapabilities:
                 capability_type=CapabilityType.TOOL,
             )
 
+    def test_get_capabilities_tool_with_raw_response(self, mcp_scan):
+        """Test get_server_capabilities returns rawResponse on tool capability."""
+        mock_response = {
+            "capabilities": [
+                {
+                    "capability_type": "TOOL",
+                    "tool": {
+                        "id": "tool-raw-001",
+                        "name": "execute_query",
+                        "description": "Execute a SQL query",
+                        "rawResponse": {
+                            "_original_id": "ext-99",
+                            "metadata": {"api_version": "v2"},
+                        },
+                    },
+                },
+            ],
+            "paging": {"total": 1, "limit": 25, "offset": 0},
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.get_server_capabilities(
+            server_id="srv-raw-001",
+            capability_type=CapabilityType.TOOL,
+        )
+
+        tool = result.capabilities[0].tool
+        assert tool.rawResponse is not None
+        assert tool.rawResponse["_original_id"] == "ext-99"
+        assert tool.rawResponse["metadata"]["api_version"] == "v2"
+
+    def test_get_capabilities_resource_with_raw_response(self, mcp_scan):
+        """Test get_server_capabilities returns rawResponse on resource capability."""
+        mock_response = {
+            "capabilities": [
+                {
+                    "capability_type": "RESOURCE",
+                    "resource": {
+                        "id": "res-raw-001",
+                        "name": "config_file",
+                        "description": "Server configuration",
+                        "uri": "file:///etc/config.yaml",
+                        "mime_type": "application/yaml",
+                        "rawResponse": {"cached": True, "ttl": 3600},
+                    },
+                },
+            ],
+            "paging": {"total": 1, "limit": 25, "offset": 0},
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.get_server_capabilities(
+            server_id="srv-raw-002",
+            capability_type=CapabilityType.RESOURCE,
+        )
+
+        resource = result.capabilities[0].resource
+        assert resource.rawResponse is not None
+        assert resource.rawResponse["cached"] is True
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestGetServerThreats
@@ -1125,6 +1237,65 @@ class TestGetServerThreats:
         with pytest.raises(ApiError):
             mcp_scan.get_server_threats(server_id="srv-error")
 
+    def test_get_threats_response_includes_source_file_and_description(self, mcp_scan):
+        """Test get_server_threats returns source_file and description in ThreatDetails."""
+        mock_response = {
+            "threats": [
+                {
+                    "capabilityId": "cap-src-001",
+                    "threat": {
+                        "techniqueId": "AITech-9.1",
+                        "techniqueName": "Code Execution",
+                        "analyzerType": "YARA",
+                        "sourceFile": "src/handlers/query_handler.py",
+                        "description": "Unsafe eval() call allows arbitrary code execution",
+                        "subTechniques": [
+                            {
+                                "subTechniqueId": "AISubtech-9.1.1",
+                                "subTechniqueName": "eval Injection",
+                                "severity": "CRITICAL",
+                            }
+                        ],
+                    },
+                },
+            ],
+            "paging": {"total": 1, "limit": 25, "offset": 0},
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.get_server_threats(server_id="srv-src-001")
+
+        assert len(result.threats) == 1
+        threat = result.threats[0].threat
+        assert threat.source_file == "src/handlers/query_handler.py"
+        assert threat.description == "Unsafe eval() call allows arbitrary code execution"
+
+    def test_get_threats_response_with_behavioral_analyzer(self, mcp_scan):
+        """Test get_server_threats parses BEHAVIORAL analyzer type."""
+        mock_response = {
+            "threats": [
+                {
+                    "capabilityId": "cap-beh-001",
+                    "threat": {
+                        "techniqueId": "AITech-5.2",
+                        "techniqueName": "Lateral Movement",
+                        "analyzerType": "BEHAVIORAL",
+                        "sourceFile": "utils/data_processor.py",
+                        "description": "Suspicious inter-process communication patterns detected",
+                        "subTechniques": [],
+                    },
+                },
+            ],
+            "paging": {"total": 1, "limit": 25, "offset": 0},
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.get_server_threats(server_id="srv-beh-001")
+
+        threat = result.threats[0].threat
+        assert threat.analyzer_type == AnalyzerType.BEHAVIORAL
+        assert threat.source_file == "utils/data_processor.py"
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestGetServerScanSummary
@@ -1250,6 +1421,60 @@ class TestGetServerScanSummary:
 
         with pytest.raises(ApiError):
             mcp_scan.get_server_scan_summary("srv-not-found")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestServerStats
+# ─────────────────────────────────────────────────────────────────────────────
+class TestServerStats:
+    """Tests for the MCPScan.server_stats method."""
+
+    def test_server_stats_success(self, mcp_scan):
+        """Test retrieving MCP server stats with expected response fields."""
+        mock_response = {
+            "stats": {
+                "riskDistribution": {
+                    "criticalCount": 2,
+                    "highCount": 5,
+                    "mediumCount": 8,
+                    "lowCount": 13,
+                },
+                "topAttackTechniques": [
+                    {"name": "Direct Prompt Injection", "count": 85},
+                    {"name": "Tool Exploitation", "count": 28},
+                ],
+                "scanCoverage": {
+                    "completedCount": 152,
+                    "inProgressCount": 42,
+                    "failedCount": 23,
+                },
+            }
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.server_stats()
+
+        mcp_scan.make_request.assert_called_once()
+        call_kwargs = mcp_scan.make_request.call_args
+        assert call_kwargs.kwargs["method"] == HttpMethod.GET
+        assert call_kwargs.kwargs["path"] == "mcp/servers:stats"
+        assert isinstance(result, GetMCPServerStatsResponse)
+        assert result.stats is not None
+        assert result.stats.risk_distribution is not None
+        assert result.stats.risk_distribution.critical_count == 2
+        assert len(result.stats.top_attack_techniques) == 2
+        assert result.stats.top_attack_techniques[0].name == "Direct Prompt Injection"
+        assert result.stats.scan_coverage is not None
+        assert result.stats.scan_coverage.completed_count == 152
+        assert result.stats.scan_coverage.in_progress_count == 42
+        assert result.stats.scan_coverage.failed_count == 23
+
+    def test_server_stats_api_error(self, mcp_scan):
+        """Test server_stats propagates ApiError."""
+        mcp_scan.make_request.side_effect = ApiError("Internal error", 500)
+
+        with pytest.raises(ApiError):
+            mcp_scan.server_stats()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1739,6 +1964,87 @@ class TestListServers:
         with pytest.raises(ApiError):
             mcp_scan.list_servers()
 
+    def test_list_servers_filter_by_scan_date(self, mcp_scan):
+        """Test list_servers passes scan_date filter in request params."""
+        from datetime import datetime, timezone
+        scan_date = datetime(2026, 3, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_response = {
+            "mcp_servers": {
+                "items": [
+                    _make_mock_server_item(
+                        server_id="srv-recent-001",
+                        name="Recently Scanned",
+                        url="https://recent.example.com/sse",
+                    ),
+                ],
+                "paging": {"total": 1, "limit": 25, "offset": 0},
+            },
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.list_servers(scan_date=scan_date)
+
+        call_kwargs = mcp_scan.make_request.call_args
+        assert "scanDate" in call_kwargs.kwargs["params"]
+        assert len(result.mcp_servers.items) == 1
+        assert result.mcp_servers.items[0].id == "srv-recent-001"
+
+    def test_list_servers_filter_by_server_types(self, mcp_scan):
+        """Test list_servers passes server_types filter in request params."""
+        mock_response = {
+            "mcp_servers": {
+                "items": [
+                    _make_mock_server_item(
+                        server_id="srv-remote-001",
+                        name="Remote MCP",
+                        url="https://remote.example.com/sse",
+                    ),
+                ],
+                "paging": {"total": 1, "limit": 25, "offset": 0},
+            },
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.list_servers(
+            server_types=[ListServerType.MCP_SERVER_REMOTE],
+        )
+
+        call_kwargs = mcp_scan.make_request.call_args
+        assert "serverTypes" in call_kwargs.kwargs["params"]
+        assert len(result.mcp_servers.items) == 1
+
+    def test_list_servers_response_includes_technique_names_and_registration_method(self, mcp_scan):
+        """Test list_servers response parses technique_names and registration_method."""
+        mock_response = {
+            "mcp_servers": {
+                "items": [
+                    {
+                        "id": "srv-fields-001",
+                        "name": "Feature-rich Server",
+                        "url": "https://featured.example.com/sse",
+                        "connectionType": "SSE",
+                        "onboarding_status": "COMPLETED",
+                        "scan_enabled": True,
+                        "auth_type": "NO_AUTH",
+                        "created_at": "2026-01-10T08:00:00Z",
+                        "techniqueNames": [
+                            "Direct Prompt Injection",
+                            "Tool Exploitation",
+                        ],
+                        "registrationMethod": "MCP_SERVER_REGISTRATION_METHOD_REGISTRY",
+                    },
+                ],
+                "paging": {"total": 1, "limit": 25, "offset": 0},
+            },
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        result = mcp_scan.list_servers()
+
+        server = result.mcp_servers.items[0]
+        assert server.technique_names == ["Direct Prompt Injection", "Tool Exploitation"]
+        assert server.registration_method == RegistrationMethod.MCP_SERVER_REGISTRATION_METHOD_REGISTRY
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestUpdateAuthConfig
@@ -2170,3 +2476,101 @@ class TestRegisteredServerScans:
 
         with pytest.raises(ApiError, match="API Error"):
             mcp_scan.trigger_server_scan("550e8400-e29b-41d4-a716-446655440003")
+
+    def test_server_scan_report_with_limit_param(self, mcp_scan):
+        """Test server_scan_report passes limit in request body."""
+        request = GetMCPServerScanReportRequest(
+            server_id="550e8400-e29b-41d4-a716-446655440010",
+            offset=0,
+            limit=10,
+            filter_options=FilterOptions(capability_type=CapabilityType.TOOL),
+        )
+        mock_response = {
+            "reports": {"items": []},
+            "paging": {"total": 0, "limit": 10, "offset": 0},
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        mcp_scan.server_scan_report(request)
+
+        call_kwargs = mcp_scan.make_request.call_args
+        assert call_kwargs.kwargs["data"]["limit"] == 10
+
+    def test_validate_servers_error_info_context_object_and_metadata(self, mcp_scan):
+        """Test validate_servers parses error_info context_object and metadata."""
+        request = ValidateMCPServersRequest(
+            urls=["https://invalid.example.com/sse"],
+            transport_type=TransportType.SSE,
+            auth_config=AuthConfig(auth_type=AuthType.NO_AUTH),
+        )
+        mock_response = {
+            "validUrls": [],
+            "invalidUrls": [
+                {
+                    "url": "https://invalid.example.com/sse",
+                    "errorInfo": {
+                        "message": "Connection failed",
+                        "errorMessage": "dial tcp timeout",
+                        "remediationTips": ["Check the URL"],
+                        "occurred_at": "2026-01-01T00:05:00Z",
+                        "contextObject": {
+                            "id": "srv-ctx-001",
+                            "name": "Invalid Server",
+                            "objectType": "MCP_SERVER",
+                        },
+                        "metadata": {
+                            "trace_id": "req-abc123",
+                            "endpoint": "/validate",
+                        },
+                    },
+                }
+            ],
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        response = mcp_scan.validate_servers(request)
+
+        error_info = response.invalid_urls[0].error_info
+        assert error_info.context_object is not None
+        assert error_info.context_object.id == "srv-ctx-001"
+        assert error_info.context_object.object_type == ContextObjectType.MCP_SERVER
+        assert error_info.metadata["trace_id"] == "req-abc123"
+
+    def test_server_scan_report_threat_source_file_and_description(self, mcp_scan):
+        """Test server_scan_report parses source_file and description from ThreatDetails."""
+        request = GetMCPServerScanReportRequest(
+            server_id="550e8400-e29b-41d4-a716-446655440011",
+            offset=0,
+            filter_options=FilterOptions(capability_type=CapabilityType.TOOL),
+        )
+        mock_response = {
+            "reports": {
+                "items": [
+                    {
+                        "capability": {
+                            "capabilityType": "TOOL",
+                            "tool": {"id": "tool-t1", "name": "run_cmd"},
+                        },
+                        "threats": [
+                            {
+                                "techniqueId": "AITech-9.1",
+                                "techniqueName": "Code Execution",
+                                "analyzerType": "BEHAVIORAL",
+                                "sourceFile": "tools/run_cmd.py",
+                                "description": "Executes arbitrary OS commands",
+                                "subTechniques": [],
+                            }
+                        ],
+                    }
+                ]
+            },
+            "paging": {"total": 1, "limit": 25, "offset": 0},
+        }
+        mcp_scan.make_request.return_value = mock_response
+
+        response = mcp_scan.server_scan_report(request)
+
+        threat = response.reports.items[0].threats[0]
+        assert threat.source_file == "tools/run_cmd.py"
+        assert threat.description == "Executes arbitrary OS commands"
+        assert threat.analyzer_type == AnalyzerType.BEHAVIORAL

--- a/aidefense/tests/test_mcpscan_routes.py
+++ b/aidefense/tests/test_mcpscan_routes.py
@@ -26,6 +26,7 @@ from aidefense.mcpscan.routes import (
     mcp_server_delete,
     mcp_server_get,
     mcp_servers_list,
+    mcp_servers_stats,
     mcp_server_update_auth_config,
     mcp_server_capabilities,
     mcp_server_threats,
@@ -69,6 +70,10 @@ class TestMCPServerRoutes:
     def test_mcp_servers_list(self):
         """Test the MCP servers list route."""
         assert mcp_servers_list() == "mcp/servers"
+
+    def test_mcp_servers_stats(self):
+        """Test the MCP servers stats route."""
+        assert mcp_servers_stats() == "mcp/servers:stats"
 
     def test_mcp_server_update_auth_config(self):
         """Test the MCP server update auth config route."""

--- a/examples/mcpscan/manage_mcp_servers.py
+++ b/examples/mcpscan/manage_mcp_servers.py
@@ -23,12 +23,14 @@ This example demonstrates how to:
 3. Get details of a specific MCP server by ID
 4. Update authentication configuration for an MCP server
 """
+from datetime import datetime, timedelta
 from enum import Enum
 import os
 
 from aidefense import Config
 from aidefense.mcpscan import MCPScan
 from aidefense.mcpscan.models import (
+    ListServerType,
     TransportType,
     AuthConfig,
     AuthType,
@@ -96,6 +98,10 @@ def print_server_details(server, verbose: bool = True) -> None:
         print(f"       High:     {server.threat_summary.high_count}")
         print(f"       Medium:   {server.threat_summary.medium_count}")
         print(f"       Low:      {server.threat_summary.low_count}")
+    if server.technique_names:
+        print(f"     Techniques Found: {', '.join(server.technique_names)}")
+    if server.registration_method:
+        print(f"     Registration Method: {server.registration_method.value if hasattr(server.registration_method, 'value') else server.registration_method}")
 
     if verbose:
         if server.status_info:
@@ -126,7 +132,13 @@ def main():
     print("=" * 50)
 
     try:
-        response = client.list_servers(limit=25, offset=0)
+        response = client.list_servers(
+            limit=25,
+            offset=0,
+            scan_date=datetime.now() - timedelta(days=1),
+            server_types=[ListServerType.MCP_SERVER_REMOTE],
+            severity=None,
+            transport_type=None,)
 
         if response.mcp_servers and response.mcp_servers.items:
             servers = response.mcp_servers.items

--- a/examples/mcpscan/mcp_server_scan.py
+++ b/examples/mcpscan/mcp_server_scan.py
@@ -30,6 +30,7 @@ from aidefense.mcpscan.models import (
     CapabilityType,
     FilterOptions,
     GetMCPServerScanReportRequest,
+    ThreatSeverityLevel,
 )
 
 from utils import (
@@ -97,8 +98,10 @@ def main():
             request=GetMCPServerScanReportRequest(
                 server_id=server_id,
                 offset=1,
+                limit=20,
                 filter_options=FilterOptions(
-                    capability_type=CapabilityType.TOOL
+                    capability_type=CapabilityType.TOOL,
+                    threat_severity=[ThreatSeverityLevel.HIGH, ThreatSeverityLevel.CRITICAL]
                 ),
             )
         )
@@ -106,6 +109,40 @@ def main():
     except Exception as e:
         print(f"❌ Failed to get scan report: {e}")
 
+    # get aggregate stats for all servers
+    print("\n📊 Retrieving aggregate MCP server stats...")
+    try:
+        stats_response = client.server_stats()
+
+        if stats_response.stats:
+            # Analyze risk distribution
+            risk = stats_response.stats.risk_distribution
+            if risk:
+                print(f"\n  Risk Distribution:")
+                print(f"    Critical: {risk.critical_count}")
+                print(f"    High:     {risk.high_count}")
+                print(f"    Medium:   {risk.medium_count}")
+                print(f"    Low:      {risk.low_count}")
+
+            # Show top attack techniques
+            if stats_response.stats.top_attack_techniques:
+                print(f"\n  Top Attack Techniques:")
+                for technique in stats_response.stats.top_attack_techniques[:5]:
+                    print(f"    - {technique.name}: {technique.count} occurrences")
+
+            # Analyze scan coverage
+            coverage = stats_response.stats.scan_coverage
+            if coverage:
+                total = coverage.completed_count + coverage.in_progress_count + coverage.failed_count
+                success_rate = (coverage.completed_count / total * 100) if total > 0 else 0
+                print(f"\n  Scan Coverage:")
+                print(f"    Completed:    {coverage.completed_count}")
+                print(f"    In Progress:  {coverage.in_progress_count}")
+                print(f"    Failed:       {coverage.failed_count}")
+                print(f"    Success Rate: {success_rate:.1f}%")
+
+    except Exception as e:
+        print(f"❌ Failed to get server stats: {e}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION

## Summary

Adds missing API coverage in MCP Scan module by implementing the MCP Server Stats endpoint.

This change extends the MCP scan client with the ability to retrieve aggregated statistics for MCP servers, including attack techniques, scan coverage metrics, and threat analysis data. The implementation includes comprehensive request/response models and unit test coverage.

## Changes

- Added `server_stats()` method to `MCPScanBase` for retrieving MCP server statistics.
- Added new response models:
  - `GetMCPServerStatsResponse` - top-level response for server stats queries.
  - `MCPServerStats` - aggregated statistics for a single MCP server.
  - `AttackTechnique` - technique data including severity and context.
  - `ScanCoverage` - capability scan coverage metrics.
  - `ContextObject` - context object reference for error/threat association.
  - `ContextObjectType` enum - types of context objects (MCP_SERVER, MCP_REGISTRY, MCP_SCAN_WORKFLOW).
- Added `RegistrationMethod` enum for MCP server registration methods (MANUAL, REGISTRY).
- Added `mcp_servers_stats()` route function for endpoint construction.
- Updated `ListMCPServersRequest` with new filtering options:
  - `scan_date` - filter by last scan date.
  - `server_types` - filter by server type (Remote/Code).
- Added `limit` field to pagination model for maximum fetch count.
- Updated model exports in `__init__.py` to include new response models and types.
- Added comprehensive unit tests in `test_mcp_scan_base.py`:
  - Tests for `server_stats()` method with various server IDs.
  - Tests for response model parsing and validation.
  - Tests for error handling and edge cases.
- Updated example scripts:
  - `manage_mcp_servers.py` - integrated stats retrieval.
  - `mcp_server_scan.py` - showcased new stats functionality.

## Test Plan

- [x] Unit tests pass in `test_mcp_scan_base.py` (404 tests added/updated).
- [x] Unit tests pass in `test_mcpscan_routes.py` (route coverage verified).
- [x] Response model parsing validated for both camelCase and snake_case fields.
- [x] Example scripts run successfully with new endpoint.
- [x] Backward compatibility maintained for existing endpoints.

## Compatibility Notes

- **Additive change**: New method and models do not impact existing functionality.
- **Client code**: Can now optionally call `server_stats()` to retrieve aggregated statistics for MCP servers.
- **Integration impact**: None - existing integrations continue to work without modification.

## Files Modified

- `aidefense/mcpscan/__init__.py` - Added model exports.
- `aidefense/mcpscan/mcp_scan_base.py` - Added `server_stats()` method (38 lines added).
- `aidefense/mcpscan/models.py` - Added new models and enums (99 lines added).
- `aidefense/mcpscan/routes.py` - Added `mcp_servers_stats()` route function.
- `aidefense/tests/test_mcp_scan_base.py` - Added comprehensive test suite (404 new lines).
- `aidefense/tests/test_mcpscan_routes.py` - Added route tests.
- `examples/mcpscan/manage_mcp_servers.py` - Updated with stats retrieval example.
- `examples/mcpscan/mcp_server_scan.py` - Enhanced with new functionality showcase (39 lines added).

**Total: 604 insertions(+), 5 deletions(-)**
