### PR TITLE
AIFW-24958: connection status unspecified not handled in event model enum

### DIFF
--- a/aidefense/management/models/connection.py
+++ b/aidefense/management/models/connection.py
@@ -36,6 +36,7 @@ class EditConnectionOperationType(str, Enum):
 class ConnectionStatus(str, Enum):
     """Connection status enum."""
 
+    Unspecified = "ConnectionStatusUnspecified"
     Connected = "Connected"
     Disconnected = "Disconnected"
     Pending = "Pending"

--- a/aidefense/tests/test_connection_management_client.py
+++ b/aidefense/tests/test_connection_management_client.py
@@ -24,6 +24,7 @@ from aidefense.management.models.connection import (
     Connection,
     Connections,
     ConnectionSortBy,
+    ConnectionStatus,
     ConnectionType,
     EditConnectionOperationType,
     ApiKeys,
@@ -169,6 +170,27 @@ class TestConnectionManagementClient:
         assert response.connection_name == "Test Connection"
         assert response.application_id == "app-123"
         assert response.connection_status == "Connected"
+
+    def test_get_connection_accepts_unspecified_status(self, connection_client):
+        """Test parsing a connection with unspecified status."""
+        mock_response = {
+            "connection": {
+                "connection_id": "conn-123",
+                "connection_name": "Test Connection",
+                "application_id": "app-123",
+                "connection_status": "ConnectionStatusUnspecified",
+            }
+        }
+        connection_client.make_request.return_value = mock_response
+
+        connection_id = "323e4567-e89b-12d3-a456-426614174333"
+        response = connection_client.get_connection(connection_id)
+
+        connection_client.make_request.assert_called_once_with(
+            "GET", f"connections/{connection_id}", params=None
+        )
+        assert isinstance(response, Connection)
+        assert response.connection_status == ConnectionStatus.Unspecified
 
     def test_create_connection(self, connection_client):
         """Test creating a connection."""

--- a/aidefense/tests/test_event_management_client.py
+++ b/aidefense/tests/test_event_management_client.py
@@ -28,6 +28,7 @@ from aidefense.management.models.event import (
     EventMessages,
     ListEventsRequest,
 )
+from aidefense.management.models.connection import ConnectionStatus
 from aidefense.management.models.common import Paging
 from aidefense.config import Config
 from aidefense.exceptions import ValidationError, ApiError, SDKError
@@ -142,6 +143,39 @@ class TestEventManagementClient:
         assert response.paging.count == 2
         assert response.paging.offset == 0
 
+    def test_list_events_accepts_unspecified_connection_status(self, event_client):
+        """Test listing expanded events with unspecified connection status."""
+        mock_response = {
+            "events": {
+                "items": [
+                    {
+                        "event_id": "event-123",
+                        "event_date": "2025-01-01T00:00:00Z",
+                        "application_id": "app-123",
+                        "connection_id": "conn-123",
+                        "event_action": "allow",
+                        "connection": {
+                            "connection_id": "conn-123",
+                            "connection_name": "Test Connection",
+                            "application_id": "app-123",
+                            "connection_status": "ConnectionStatusUnspecified",
+                        },
+                    }
+                ],
+                "paging": {"total": 1, "count": 1, "offset": 0},
+            }
+        }
+        event_client.make_request.return_value = mock_response
+
+        request = ListEventsRequest(limit=1, expanded=True)
+        response = event_client.list_events(request)
+
+        event_client.make_request.assert_called_once_with(
+            "POST", "events", data={"limit": 1, "expanded": True}
+        )
+        assert isinstance(response, Events)
+        assert response.items[0].connection.connection_status == ConnectionStatus.Unspecified
+
     def test_get_event(self, event_client):
         """Test getting an event by ID."""
         # Setup mock response
@@ -193,6 +227,34 @@ class TestEventManagementClient:
         assert response.rule_matches.items[0].guardrail_type == "Security"
         assert response.rule_matches.items[0].guardrail_action == "block"
         assert "PCI DSS" in response.rule_matches.items[0].metadata.standards
+
+    def test_get_event_accepts_unspecified_connection_status(self, event_client):
+        """Test getting an expanded event with unspecified connection status."""
+        mock_response = {
+            "event": {
+                "event_id": "event-123",
+                "event_date": "2025-01-01T00:00:00Z",
+                "application_id": "app-123",
+                "connection_id": "conn-123",
+                "event_action": "allow",
+                "connection": {
+                    "connection_id": "conn-123",
+                    "connection_name": "Test Connection",
+                    "application_id": "app-123",
+                    "connection_status": "ConnectionStatusUnspecified",
+                },
+            }
+        }
+        event_client.make_request.return_value = mock_response
+
+        event_id = "456e4567-e89b-12d3-a456-426614174456"
+        response = event_client.get_event(event_id, expanded=True)
+
+        event_client.make_request.assert_called_once_with(
+            "GET", f"events/{event_id}", params={"expanded": True}
+        )
+        assert isinstance(response, Event)
+        assert response.connection.connection_status == ConnectionStatus.Unspecified
 
     def test_get_event_conversation(self, event_client):
         """Test getting a conversation for an event."""

--- a/examples/management/management_client_usage.py
+++ b/examples/management/management_client_usage.py
@@ -413,7 +413,7 @@ def main():
 
                     # Get event conversation using the new method signature with separate ID parameter
                     conversation = client.events.get_event_conversation(
-                        first_event.event_id, expanded=True
+                        first_event.event_id
                     )
 
                     if "messages" in conversation and conversation["messages"].items:


### PR DESCRIPTION
## Summary

Adds support for the API value `ConnectionStatusUnspecified` in management connection models.

This change prevents parsing failures when connection or expanded event responses include an unspecified connection status. It adds enum coverage, validates the behavior through connection and event client unit tests, and updates one management example call to match the current event conversation API signature.

## Changes

- Added `ConnectionStatus.Unspecified` enum value mapped to `ConnectionStatusUnspecified`.
- Added unit test coverage for `get_connection()` parsing connections with unspecified status.
- Added unit test coverage for expanded event responses containing connections with unspecified status:
  - `list_events()`
  - `get_event()`
- Updated `management_client_usage.py` to call `get_event_conversation(first_event.event_id)` without the removed/unsupported `expanded=True` argument.

## Test Plan

- [x] Branch diff inspected against `main`.
- [x] Targeted test files identified:
  - `aidefense/tests/test_connection_management_client.py`
  - `aidefense/tests/test_event_management_client.py`

## Compatibility Notes

- **Additive change**: Adds a new enum member without changing existing enum values.
- **Client code**: Existing callers continue to work; responses containing `ConnectionStatusUnspecified` now parse correctly.
- **Integration impact**: Low risk. This fixes handling for an API value that can already appear in responses.

## Files Modified

- `aidefense/management/models/connection.py` - Added `ConnectionStatus.Unspecified`.
- `aidefense/tests/test_connection_management_client.py` - Added connection parsing test for unspecified status.
- `aidefense/tests/test_event_management_client.py` - Added expanded event parsing tests for unspecified connection status.
- `examples/management/management_client_usage.py` - Updated `get_event_conversation()` example call.

**Total: 86 insertions(+), 1 deletion(-)**
