### PR TITLE
feat: support per-request API key for runtime inspection clients

### DIFF
--- a/aidefense/runtime/chat_inspect.py
+++ b/aidefense/runtime/chat_inspect.py
@@ -172,12 +172,13 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
             If not provided, a default singleton Config is used.
     """
 
-    def __init__(self, api_key: str, config: Config = None):
+    def __init__(self, api_key: Optional[str] = None, config: Config = None):
         """
         Initialize a ChatInspectionClient instance.
 
         Args:
-            api_key (str): Your Cisco AI Defense API key for authentication.
+            api_key (str, optional): Your Cisco AI Defense API key for authentication. May be omitted
+                to construct a client that requires a per-request api_key on each inspection call.
             config (Config, optional): SDK-level configuration for endpoints, logging, retries, etc.
                 This is NOT the InspectionConfig used in API requests, but the SDK-level configuration from aidefense/config.py.
         """
@@ -194,6 +195,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect a single user prompt for security, privacy, and safety violations.
@@ -204,6 +206,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout(int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -235,7 +238,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
             f"Inspecting prompt: {prompt} | Metadata: {metadata}, Config: {config}, Request ID: {request_id}"
         )
         message = Message(role=Role.USER, content=prompt)
-        return self._inspect([message], metadata, config, request_id, timeout)
+        return self._inspect([message], metadata, config, request_id, timeout, api_key)
 
     def inspect_response(
         self,
@@ -244,6 +247,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect a single AI response for security, privacy, and safety risks.
@@ -254,6 +258,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -296,7 +301,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
             f"Inspecting AI response: {response} | Metadata: {metadata}, Config: {config}, Request ID: {request_id}"
         )
         message = Message(role=Role.ASSISTANT, content=response)
-        return self._inspect([message], metadata, config, request_id, timeout)
+        return self._inspect([message], metadata, config, request_id, timeout, api_key)
 
     def inspect_conversation(
         self,
@@ -305,6 +310,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect a full conversation (list of messages) for security, privacy, and safety risks.
@@ -315,6 +321,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -372,7 +379,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
         self.config.logger.debug(
             f"Inspecting conversation with {len(messages)} messages. | Messages: {messages}, Metadata: {metadata}, Config: {config}, Request ID: {request_id}"
         )
-        return self._inspect(messages, metadata, config, request_id, timeout)
+        return self._inspect(messages, metadata, config, request_id, timeout, api_key)
 
     def _inspect(
         self,
@@ -381,6 +388,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Implements the inspection logic for chat conversations.
@@ -394,6 +402,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -405,7 +414,7 @@ class ChatInspectionClient(BaseChatInspectionClient, InspectionClient):
         result = self._request_handler.request(
             method="POST",
             url=self.endpoint,
-            auth=self.auth,
+            auth=self._resolve_auth(api_key),
             headers=headers,
             json_data=request_dict,
             request_id=request_id,
@@ -433,12 +442,13 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
             If not provided, a default singleton Config is used.
     """
 
-    def __init__(self, api_key: str, config: AsyncConfig = None):
+    def __init__(self, api_key: Optional[str] = None, config: AsyncConfig = None):
         """
         Initialize an AsyncChatInspectionClient instance.
 
         Args:
-            api_key (str): Your Cisco AI Defense API key for authentication.
+            api_key (str, optional): Your Cisco AI Defense API key for authentication. May be omitted
+                to construct a client that requires a per-request api_key on each inspection call.
             config (AsyncConfig, optional): Async SDK configuration for endpoints, logging, retries, etc.
                 If not provided, a default singleton AsyncConfig is used.
 
@@ -458,6 +468,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect a single user prompt for security, privacy, and safety violations.
@@ -468,6 +479,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout(int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -498,7 +510,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
             f"Inspecting prompt: {prompt} | Metadata: {metadata}, Config: {config}, Request ID: {request_id}"
         )
         message = Message(role=Role.USER, content=prompt)
-        return await self._inspect([message], metadata, config, request_id, timeout)
+        return await self._inspect([message], metadata, config, request_id, timeout, api_key)
 
     async def inspect_response(
         self,
@@ -507,6 +519,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect a single AI response for security, privacy, and safety risks.
@@ -517,6 +530,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds. Overrides the default timeout.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -558,7 +572,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
             f"Inspecting AI response: {response} | Metadata: {metadata}, Config: {config}, Request ID: {request_id}"
         )
         message = Message(role=Role.ASSISTANT, content=response)
-        return await self._inspect([message], metadata, config, request_id, timeout)
+        return await self._inspect([message], metadata, config, request_id, timeout, api_key)
 
     async def inspect_conversation(
         self,
@@ -567,6 +581,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect a full conversation (list of messages) for security, privacy, and safety risks.
@@ -577,6 +592,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds. Overrides the default client timeout if provided.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -633,7 +649,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
         self.config.logger.debug(
             f"Inspecting conversation with {len(messages)} messages. | Messages: {messages}, Metadata: {metadata}, Config: {config}, Request ID: {request_id}"
         )
-        return await self._inspect(messages, metadata, config, request_id, timeout)
+        return await self._inspect(messages, metadata, config, request_id, timeout, api_key)
 
     async def _inspect(
         self,
@@ -642,6 +658,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Implements the inspection logic for chat conversations.
@@ -655,6 +672,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             InspectResponse: Inspection results as an InspectResponse object.
@@ -666,7 +684,7 @@ class AsyncChatInspectionClient(BaseChatInspectionClient, AsyncInspectionClient)
         result = await self._request_handler.request(
             method="POST",
             url=self.endpoint,
-            auth=self.auth,
+            auth=self._resolve_auth(api_key),
             headers=headers,
             json_data=request_dict,
             request_id=request_id,

--- a/aidefense/runtime/http_inspect.py
+++ b/aidefense/runtime/http_inspect.py
@@ -55,12 +55,13 @@ class HttpInspectionClient(InspectionClient):
         Rule, RuleName, HttpInspectRequest, ...: Shortcuts for internal models and enums.
     """
 
-    def __init__(self, api_key: str, config: Config = None):
+    def __init__(self, api_key: Optional[str] = None, config: Config = None):
         """
         Create a new HTTP inspection client.
 
         Args:
-            api_key (str): Your AI Defense API key.
+            api_key (str, optional): Your AI Defense API key. May be omitted to construct a client
+                that requires a per-request api_key on each inspection call.
             config (Config, optional): SDK configuration for endpoints, logging, retries, etc.
         """
         config = config or Config()
@@ -76,6 +77,7 @@ class HttpInspectionClient(InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Direct interface for HTTP inspection API using dicts for http_req, http_res, and http_meta.
@@ -89,6 +91,7 @@ class HttpInspectionClient(InspectionClient):
             config (InspectionConfig, optional): Inspection configuration.
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Note:
             - The 'body' field for both request and response dicts must be a base64-encoded string representing the original bytes.
@@ -151,6 +154,7 @@ class HttpInspectionClient(InspectionClient):
             config,
             request_id=request_id,
             timeout=timeout,
+            api_key=api_key,
         )
 
     def inspect_request_from_http_library(
@@ -160,6 +164,7 @@ class HttpInspectionClient(InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect an HTTP request from a supported HTTP library (currently requests) that is being sent to the model provider.
@@ -170,6 +175,7 @@ class HttpInspectionClient(InspectionClient):
             config (InspectionConfig, optional): Optional inspection configuration (rules, etc.).
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Example:
             ```python
@@ -237,6 +243,7 @@ class HttpInspectionClient(InspectionClient):
             config,
             request_id=request_id,
             timeout=timeout,
+            api_key=api_key,
         )
 
     def inspect_response_from_http_library(
@@ -246,6 +253,7 @@ class HttpInspectionClient(InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect an HTTP response from a supported HTTP library (currently requests) that comes from model provider and return inspection results.
@@ -256,6 +264,7 @@ class HttpInspectionClient(InspectionClient):
             config (InspectionConfig, optional): Inspection configuration.
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Example:
             ```python
@@ -333,6 +342,7 @@ class HttpInspectionClient(InspectionClient):
             config,
             request_id=request_id,
             timeout=timeout,
+            api_key=api_key,
         )
 
     def inspect_request(
@@ -345,6 +355,7 @@ class HttpInspectionClient(InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect an HTTP request with simplified arguments (method, url, headers, body).
@@ -358,6 +369,7 @@ class HttpInspectionClient(InspectionClient):
             config (InspectionConfig, optional): Inspection configuration.
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Example:
             ```python
@@ -423,6 +435,7 @@ class HttpInspectionClient(InspectionClient):
             config,
             request_id=request_id,
             timeout=timeout,
+            api_key=api_key,
         )
 
     def inspect_response(
@@ -439,6 +452,7 @@ class HttpInspectionClient(InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Inspect an HTTP response (status code, url, headers, body), with request context and metadata, for security, privacy, and policy violations.
@@ -456,6 +470,7 @@ class HttpInspectionClient(InspectionClient):
             config (InspectionConfig, optional): Inspection configuration rules.
             request_id (str, optional): Unique identifier for the request (usually a UUID) to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Example:
             ```python
@@ -570,6 +585,7 @@ class HttpInspectionClient(InspectionClient):
             config,
             request_id=request_id,
             timeout=timeout,
+            api_key=api_key,
         )
 
     def _inspect(
@@ -581,6 +597,7 @@ class HttpInspectionClient(InspectionClient):
         config: Optional[InspectionConfig] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> InspectResponse:
         """
         Implements InspectionClient._inspect for HTTP inspection.
@@ -612,7 +629,7 @@ class HttpInspectionClient(InspectionClient):
         result = self._request_handler.request(
             method="POST",
             url=self.endpoint,
-            auth=self.auth,
+            auth=self._resolve_auth(api_key),
             headers=headers,
             json_data=request_dict,
             request_id=request_id,

--- a/aidefense/runtime/inspection_client.py
+++ b/aidefense/runtime/inspection_client.py
@@ -15,10 +15,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import abstractmethod, ABC
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from dataclasses import asdict
 
 from .auth import RuntimeAuth, AsyncAuth
+from ..exceptions import ValidationError
 from .models import PII_ENTITIES, PCI_ENTITIES, PHI_ENTITIES
 from .models import (
     Action,
@@ -362,25 +363,53 @@ class InspectionClient(BaseInspectionClient):
 
         return super().__new__(cls)
 
-    def __init__(self, api_key: str, config: Config):
+    def __init__(self, api_key: Optional[str] = None, config: Config = None):
         """
         Initialize the InspectionClient.
 
         Args:
-            api_key (str): Your AI Defense API key for authentication.
+            api_key (str, optional): Your AI Defense API key for authentication. May be omitted
+                to construct a client that requires a per-request api_key on each call.
             config (Config, optional): SDK configuration for endpoints, logging, retries, etc.
                 If not provided, a default singleton Config is used.
 
         Attributes:
-            auth (RuntimeAuth): Authentication object for API requests.
+            auth (RuntimeAuth): Authentication object for API requests, or None when no
+                construction-time key was provided.
             config (Config): The runtime configuration object.
             api_key (str): The API key used for authentication.
             default_enabled_rules (list): List of Rule objects for all RuleNames. Only rules present in
                 DEFAULT_ENTITY_MAP (PII, PCI, PHI) will have their associated entity_types set; all others will have entity_types as None.
         """
         super().__init__(api_key, config)
-        self.auth = RuntimeAuth(api_key)
+        self.auth = RuntimeAuth(api_key) if api_key else None
         self._request_handler = RequestHandler(config)
+
+    def _resolve_auth(self, api_key: Optional[str]) -> RuntimeAuth:
+        """
+        Resolve the authentication object for a request.
+
+        A per-request api_key takes precedence over the construction-time key, allowing
+        a single client to authenticate different calls with different keys.
+
+        Args:
+            api_key (str, optional): Per-request API key. If provided, it is validated and used
+                for this request only. If omitted, the construction-time key is used.
+
+        Returns:
+            RuntimeAuth: The authentication object to use for the request.
+
+        Raises:
+            ValueError: If a provided per-request api_key has an invalid format.
+            ValidationError: If no api_key is available from either source.
+        """
+        if api_key:
+            return RuntimeAuth(api_key)
+        if self.auth:
+            return self.auth
+        raise ValidationError(
+            "No API key available: pass api_key to this method or to the client constructor."
+        )
 
     def _inspect(self, *args, **kwargs):
         """
@@ -432,17 +461,44 @@ class AsyncInspectionClient(BaseInspectionClient):
 
         return super().__new__(cls)
 
-    def __init__(self, api_key: str, config: AsyncConfig):
+    def __init__(self, api_key: Optional[str] = None, config: AsyncConfig = None):
         """
         Initialize the async inspection client.
 
         Args:
-            api_key (str): Your AI Defense API key for authentication.
+            api_key (str, optional): Your AI Defense API key for authentication. May be omitted
+                to construct a client that requires a per-request api_key on each call.
             config (AsyncConfig): Async SDK configuration for endpoints, logging, retries, etc.
         """
         super().__init__(api_key, config)
-        self.auth = AsyncAuth(api_key)
+        self.auth = AsyncAuth(api_key) if api_key else None
         self._request_handler = AsyncRequestHandler(config)
+
+    def _resolve_auth(self, api_key: Optional[str]) -> AsyncAuth:
+        """
+        Resolve the authentication object for a request.
+
+        A per-request api_key takes precedence over the construction-time key, allowing
+        a single client to authenticate different calls with different keys.
+
+        Args:
+            api_key (str, optional): Per-request API key. If provided, it is validated and used
+                for this request only. If omitted, the construction-time key is used.
+
+        Returns:
+            AsyncAuth: The authentication object to use for the request.
+
+        Raises:
+            ValueError: If a provided per-request api_key has an invalid format.
+            ValidationError: If no api_key is available from either source.
+        """
+        if api_key:
+            return AsyncAuth(api_key)
+        if self.auth:
+            return self.auth
+        raise ValidationError(
+            "No API key available: pass api_key to this method or to the client constructor."
+        )
 
     async def __aenter__(self):
         """

--- a/aidefense/runtime/mcp_inspect.py
+++ b/aidefense/runtime/mcp_inspect.py
@@ -79,12 +79,13 @@ class MCPInspectionClient(InspectionClient):
         endpoint (str): The API endpoint for MCP inspection requests.
     """
 
-    def __init__(self, api_key: str, config: Config = None):
+    def __init__(self, api_key: Optional[str] = None, config: Config = None):
         """
         Initialize an MCPInspectionClient instance.
 
         Args:
-            api_key (str): Your Cisco AI Defense API key for authentication.
+            api_key (str, optional): Your Cisco AI Defense API key for authentication. May be omitted
+                to construct a client that requires a per-request api_key on each inspection call.
             config (Config, optional): SDK-level configuration for endpoints, logging, retries, etc.
         """
         config = config or Config()
@@ -96,6 +97,7 @@ class MCPInspectionClient(InspectionClient):
         message: MCPMessage,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> MCPInspectResponse:
         """
         Inspect an MCP JSON-RPC 2.0 message for security, privacy, and safety violations.
@@ -107,6 +109,7 @@ class MCPInspectionClient(InspectionClient):
             request_id (str, optional): Unique identifier for the request (usually a UUID)
                 to enable request tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             MCPInspectResponse: Inspection results wrapped in JSON-RPC 2.0 format.
@@ -148,7 +151,7 @@ class MCPInspectionClient(InspectionClient):
         self.config.logger.debug(
             f"Inspecting MCP message: {message} | Request ID: {request_id}"
         )
-        return self._inspect(message, request_id, timeout)
+        return self._inspect(message, request_id, timeout, api_key)
 
     def inspect_tool_call(
         self,
@@ -157,6 +160,7 @@ class MCPInspectionClient(InspectionClient):
         message_id: Optional[Union[str, int]] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> MCPInspectResponse:
         """
         Convenience method to inspect an MCP tools/call request.
@@ -167,6 +171,7 @@ class MCPInspectionClient(InspectionClient):
             message_id (Union[str, int], optional): The JSON-RPC message ID.
             request_id (str, optional): Unique identifier for the request to enable tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             MCPInspectResponse: Inspection results wrapped in JSON-RPC 2.0 format.
@@ -199,7 +204,7 @@ class MCPInspectionClient(InspectionClient):
             params={"name": tool_name, "arguments": arguments or {}},
             id=message_id,
         )
-        return self._inspect(message, request_id, timeout)
+        return self._inspect(message, request_id, timeout, api_key)
 
     def inspect_resource_read(
         self,
@@ -207,6 +212,7 @@ class MCPInspectionClient(InspectionClient):
         message_id: Optional[Union[str, int]] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> MCPInspectResponse:
         """
         Convenience method to inspect an MCP resources/read request.
@@ -216,6 +222,7 @@ class MCPInspectionClient(InspectionClient):
             message_id (Union[str, int], optional): The JSON-RPC message ID.
             request_id (str, optional): Unique identifier for the request to enable tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             MCPInspectResponse: Inspection results wrapped in JSON-RPC 2.0 format.
@@ -247,7 +254,7 @@ class MCPInspectionClient(InspectionClient):
             params={"uri": uri},
             id=message_id,
         )
-        return self._inspect(message, request_id, timeout)
+        return self._inspect(message, request_id, timeout, api_key)
 
     def inspect_prompt_get(
         self,
@@ -256,6 +263,7 @@ class MCPInspectionClient(InspectionClient):
         message_id: Optional[Union[str, int]] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> MCPInspectResponse:
         """
         Convenience method to inspect an MCP prompts/get request.
@@ -266,6 +274,7 @@ class MCPInspectionClient(InspectionClient):
             message_id (Union[str, int], optional): The JSON-RPC message ID.
             request_id (str, optional): Unique identifier for the request to enable tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             MCPInspectResponse: Inspection results wrapped in JSON-RPC 2.0 format.
@@ -282,7 +291,7 @@ class MCPInspectionClient(InspectionClient):
             params={"name": prompt_name, "arguments": arguments or {}},
             id=message_id,
         )
-        return self._inspect(message, request_id, timeout)
+        return self._inspect(message, request_id, timeout, api_key)
 
     def inspect_response(
         self,
@@ -292,6 +301,7 @@ class MCPInspectionClient(InspectionClient):
         message_id: Optional[Union[str, int]] = None,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> MCPInspectResponse:
         """
         Convenience method to inspect an MCP response message.
@@ -308,6 +318,7 @@ class MCPInspectionClient(InspectionClient):
             message_id (Union[str, int], optional): The JSON-RPC message ID.
             request_id (str, optional): Unique identifier for the request to enable tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             MCPInspectResponse: Inspection results wrapped in JSON-RPC 2.0 format.
@@ -354,13 +365,14 @@ class MCPInspectionClient(InspectionClient):
             result=result_data,
             id=message_id,
         )
-        return self._inspect(message, request_id, timeout)
+        return self._inspect(message, request_id, timeout, api_key)
 
     def _inspect(
         self,
         message: MCPMessage,
         request_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        api_key: Optional[str] = None,
     ) -> MCPInspectResponse:
         """
         Implements the inspection logic for MCP messages.
@@ -372,6 +384,7 @@ class MCPInspectionClient(InspectionClient):
             message (MCPMessage): The MCP message to inspect.
             request_id (str, optional): Unique identifier for the request to enable tracing.
             timeout (int, optional): Request timeout in seconds.
+            api_key (str, optional): Per-request API key. Overrides the construction-time key for this call only.
 
         Returns:
             MCPInspectResponse: Inspection results wrapped in JSON-RPC 2.0 format.
@@ -393,7 +406,7 @@ class MCPInspectionClient(InspectionClient):
         result = self._request_handler.request(
             method="POST",
             url=self.endpoint,
-            auth=self.auth,
+            auth=self._resolve_auth(api_key),
             headers=headers,
             json_data=request_dict,
             request_id=request_id,

--- a/aidefense/tests/test_per_request_api_key.py
+++ b/aidefense/tests/test_per_request_api_key.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for per-request API key override across runtime inspection clients."""
+
+import pytest
+from unittest.mock import Mock, AsyncMock
+
+from aidefense import (
+    ChatInspectionClient,
+    AsyncChatInspectionClient,
+    HttpInspectionClient,
+    Config,
+    AsyncConfig,
+)
+from aidefense.runtime.mcp_inspect import MCPInspectionClient
+from aidefense.runtime.mcp_models import MCPMessage
+from aidefense.exceptions import ValidationError
+
+
+KEY_A = "a" * 64
+KEY_B = "b" * 64
+RESPONSE = {"is_safe": True, "classifications": [], "action": "Allow"}
+MCP_RESPONSE = {"jsonrpc": "2.0", "result": RESPONSE, "id": 1}
+
+
+@pytest.fixture(autouse=True)
+def reset_config_singleton():
+    Config._instances = {}
+    AsyncConfig._instances = {}
+    yield
+    Config._instances = {}
+    AsyncConfig._instances = {}
+
+
+def _sent_auth(mock_handler):
+    return mock_handler.request.call_args.kwargs["auth"]
+
+
+def _make_chat(api_key):
+    client = ChatInspectionClient(api_key=api_key, config=Config())
+    client._request_handler = Mock()
+    client._request_handler.request.return_value = RESPONSE
+    return client
+
+
+def _make_http(api_key):
+    client = HttpInspectionClient(api_key=api_key, config=Config())
+    client._request_handler = Mock()
+    client._request_handler.VALID_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE"]
+    client._request_handler.request.return_value = RESPONSE
+    return client
+
+
+def _make_mcp(api_key):
+    client = MCPInspectionClient(api_key=api_key, config=Config())
+    client._request_handler = Mock()
+    client._request_handler.request.return_value = MCP_RESPONSE
+    return client
+
+
+def _call_chat(client, api_key=None):
+    return client.inspect_prompt("hello", api_key=api_key)
+
+
+def _call_http(client, api_key=None):
+    return client.inspect_request(
+        method="POST", url="https://example.com", body="x", api_key=api_key
+    )
+
+
+def _call_mcp(client, api_key=None):
+    msg = MCPMessage(jsonrpc="2.0", method="tools/call", params={"name": "t", "arguments": {}}, id=1)
+    return client.inspect(message=msg, api_key=api_key)
+
+
+SYNC_CLIENTS = [
+    pytest.param(_make_chat, _call_chat, id="chat"),
+    pytest.param(_make_http, _call_http, id="http"),
+    pytest.param(_make_mcp, _call_mcp, id="mcp"),
+]
+
+
+@pytest.mark.parametrize("make_client, call", SYNC_CLIENTS)
+def test_per_call_key_overrides_construction_key(make_client, call):
+    client = make_client(KEY_A)
+    call(client, api_key=KEY_B)
+    assert _sent_auth(client._request_handler).token == KEY_B
+
+
+@pytest.mark.parametrize("make_client, call", SYNC_CLIENTS)
+def test_falls_back_to_construction_key(make_client, call):
+    client = make_client(KEY_A)
+    call(client)
+    assert _sent_auth(client._request_handler).token == KEY_A
+
+
+@pytest.mark.parametrize("make_client, call", SYNC_CLIENTS)
+def test_no_construction_key_uses_per_call_key(make_client, call):
+    client = make_client(None)
+    assert client.auth is None
+    call(client, api_key=KEY_B)
+    assert _sent_auth(client._request_handler).token == KEY_B
+
+
+@pytest.mark.parametrize("make_client, call", SYNC_CLIENTS)
+def test_no_key_anywhere_raises(make_client, call):
+    client = make_client(None)
+    with pytest.raises(ValidationError):
+        call(client)
+
+
+@pytest.mark.parametrize("make_client, call", SYNC_CLIENTS)
+def test_invalid_per_call_key_raises(make_client, call):
+    client = make_client(KEY_A)
+    with pytest.raises(ValueError):
+        call(client, api_key="too-short")
+
+
+@pytest.mark.asyncio
+async def test_async_chat_per_request_key():
+    client = AsyncChatInspectionClient(api_key=KEY_A, config=AsyncConfig())
+    client._request_handler = AsyncMock()
+    client._request_handler.request.return_value = RESPONSE
+
+    await client.inspect_prompt("hello", api_key=KEY_B)
+    assert client._request_handler.request.call_args.kwargs["auth"].token == KEY_B
+
+    await client.inspect_prompt("hello")
+    assert client._request_handler.request.call_args.kwargs["auth"].token == KEY_A
+
+
+@pytest.mark.asyncio
+async def test_async_chat_no_key_anywhere_raises():
+    client = AsyncChatInspectionClient(config=AsyncConfig())
+    client._request_handler = AsyncMock()
+    assert client.auth is None
+    with pytest.raises(ValidationError):
+        await client.inspect_prompt("hello")


### PR DESCRIPTION
## What

Adds an optional `api_key` argument to every runtime inspection method (Chat sync/async, HTTP, and MCP clients), allowing callers to override the API key on a per-request basis. Clients can also now be constructed **without** a key for purely per-request usage.

## Why

The AI Defense API authenticates each call with an HTTP header (`X-Cisco-AI-Defense-API-Key`) stamped onto every request — the key is inherently per-request and not bound to a connection or session. The SDK, however, pinned the key at client construction (`self.auth`), forcing one client (and one connection pool) per key.

This is limiting for multi-tenant services and key-rotation scenarios, where a single shared client should be able to authenticate different calls with different keys without rebuilding the client or its connection pool each time. Per-request auth override is a well-established pattern (`requests`/`httpx` per-call `headers=`/`auth=`, Stripe's per-call `api_key=`).

## How

Auth is now resolved per call via a small `_resolve_auth(api_key)` helper on the base inspection clients:

- A per-request `api_key` takes precedence over the construction-time key.
- When omitted, it falls back to the construction-time key (unchanged behavior).
- When neither is available, it raises a clear `ValidationError` at call time.

The transport layer already accepted per-call `auth`, so no request-handler or auth-class changes were needed.

```python
client = ChatInspectionClient(api_key=DEFAULT_KEY)
client.inspect_prompt("hi")                      # uses DEFAULT_KEY (unchanged)
client.inspect_prompt("hi", api_key=TENANT_KEY)  # per-request override

keyless = ChatInspectionClient()                 # no key at construction
keyless.inspect_prompt("hi", api_key=TENANT_KEY) # works
```

## Backwards compatibility

Fully backwards compatible — all new parameters default to `None` and existing call sites are unaffected.

## Tests

Adds `tests/test_per_request_api_key.py` covering per-call override, fallback, no-key construction, the no-key-anywhere error, and invalid-key validation, parameterized across the sync chat/HTTP/MCP clients plus the async chat client. Full existing suite remains green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
