### PR TITLE
Proxy stream attributes in LiteLLM streaming wrapper

### DIFF
--- a/aidefense/runtime/agentsec/patchers/litellm.py
+++ b/aidefense/runtime/agentsec/patchers/litellm.py
@@ -141,6 +141,23 @@ class _LiteLLMStreamingInspectionWrapper:
         self._inspect_interval = 10
         self._final_inspection_done = False
 
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def close(self) -> None:
+        self._perform_final_inspection()
+        if hasattr(self._stream, "close"):
+            self._stream.close()
+
     def __iter__(self):
         return self
 
@@ -216,6 +233,25 @@ class _AsyncLiteLLMStreamingInspectionWrapper:
         self._chunk_count = 0
         self._inspect_interval = 10
         self._final_inspection_done = False
+
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.aclose()
+        return False
+
+    async def aclose(self) -> None:
+        await self._perform_final_inspection()
+        if hasattr(self._stream, "aclose"):
+            await self._stream.aclose()
+        elif hasattr(self._stream, "close"):
+            self._stream.close()
 
     def __aiter__(self):
         return self

--- a/aidefense/runtime/agentsec/patchers/litellm.py
+++ b/aidefense/runtime/agentsec/patchers/litellm.py
@@ -154,9 +154,11 @@ class _LiteLLMStreamingInspectionWrapper:
         return False
 
     def close(self) -> None:
-        self._perform_final_inspection()
-        if hasattr(self._stream, "close"):
-            self._stream.close()
+        try:
+            self._perform_final_inspection()
+        finally:
+            if hasattr(self._stream, "close"):
+                self._stream.close()
 
     def __iter__(self):
         return self
@@ -247,11 +249,13 @@ class _AsyncLiteLLMStreamingInspectionWrapper:
         return False
 
     async def aclose(self) -> None:
-        await self._perform_final_inspection()
-        if hasattr(self._stream, "aclose"):
-            await self._stream.aclose()
-        elif hasattr(self._stream, "close"):
-            self._stream.close()
+        try:
+            await self._perform_final_inspection()
+        finally:
+            if hasattr(self._stream, "aclose"):
+                await self._stream.aclose()
+            elif hasattr(self._stream, "close"):
+                self._stream.close()
 
     def __aiter__(self):
         return self

--- a/aidefense/tests/agentsec/unit/test_litellm_patcher.py
+++ b/aidefense/tests/agentsec/unit/test_litellm_patcher.py
@@ -17,12 +17,12 @@
 """Unit tests for the LiteLLM patcher.
 
 Covers patch_litellm(), _detect_provider(), _should_inspect(), _extract_response_text(),
-_wrap_completion() (API + gateway mode), and _handle_patcher_error()-equivalent paths.
+_wrap_completion() (API + gateway mode), streaming wrappers, and _handle_patcher_error()-equivalent paths.
 """
 
 import pytest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aidefense.runtime.agentsec.patchers.litellm import (
     patch_litellm,
@@ -31,6 +31,8 @@ from aidefense.runtime.agentsec.patchers.litellm import (
     _enforce_decision,
     _extract_response_text,
     _wrap_completion,
+    _LiteLLMStreamingInspectionWrapper,
+    _AsyncLiteLLMStreamingInspectionWrapper,
 )
 from aidefense.runtime.agentsec.exceptions import SecurityPolicyError
 from aidefense.runtime.agentsec.decision import Decision
@@ -602,3 +604,144 @@ class TestWrapCompletionArgsParsing:
             {},
         )
         mock_wrapped.assert_called_once()
+
+
+# ===========================================================================
+# _LiteLLMStreamingInspectionWrapper
+# ===========================================================================
+
+class TestLiteLLMStreamingInspectionWrapper:
+    """Test sync streaming wrapper attribute proxying and iteration."""
+
+    def test_proxies_headers_to_underlying_stream(self):
+        mock_stream = SimpleNamespace(
+            headers={"x-ratelimit-remaining-requests": "99"},
+        )
+        wrapper = _LiteLLMStreamingInspectionWrapper(mock_stream, [], {})
+        assert wrapper.headers == {"x-ratelimit-remaining-requests": "99"}
+
+    def test_proxies_arbitrary_attribute(self):
+        mock_stream = SimpleNamespace(model="azure/gpt-4")
+        wrapper = _LiteLLMStreamingInspectionWrapper(mock_stream, [], {})
+        assert wrapper.model == "azure/gpt-4"
+
+    def test_private_attribute_on_underlying_stream_not_proxied(self):
+        mock_stream = SimpleNamespace(_internal="secret", headers={})
+        wrapper = _LiteLLMStreamingInspectionWrapper(mock_stream, [], {})
+        with pytest.raises(AttributeError):
+            _ = wrapper._internal
+
+    @patch("aidefense.runtime.agentsec.patchers.litellm._get_inspector")
+    def test_wrap_completion_returns_wrapper_for_streaming(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.allow(reasons=[])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        mock_stream = SimpleNamespace(
+            headers={"x-ms-region": "eastus"},
+            __iter__=lambda self: iter([]),
+        )
+        mock_wrapped = MagicMock(return_value=mock_stream)
+
+        result = _wrap_completion(
+            mock_wrapped, None, (),
+            {
+                "model": "azure/gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+        assert isinstance(result, _LiteLLMStreamingInspectionWrapper)
+        assert result.headers == {"x-ms-region": "eastus"}
+
+    @patch("aidefense.runtime.agentsec.patchers.litellm._get_inspector")
+    def test_iterates_chunks_and_performs_final_inspection(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.allow(reasons=[])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hi"))],
+        )
+        mock_stream = SimpleNamespace(headers={})
+        stream = iter([chunk])
+
+        wrapper = _LiteLLMStreamingInspectionWrapper(
+            stream,
+            [{"role": "user", "content": "Hello"}],
+            {},
+        )
+        chunks = list(wrapper)
+        assert len(chunks) == 1
+        assert mock_inspector.inspect_conversation.called
+
+
+class TestAsyncLiteLLMStreamingInspectionWrapper:
+    """Test async streaming wrapper attribute proxying."""
+
+    def test_proxies_headers_to_underlying_stream(self):
+        mock_stream = SimpleNamespace(
+            headers={"x-ratelimit-remaining-tokens": "1000"},
+        )
+        wrapper = _AsyncLiteLLMStreamingInspectionWrapper(mock_stream, [], {})
+        assert wrapper.headers == {"x-ratelimit-remaining-tokens": "1000"}
+
+    def test_private_attribute_on_underlying_stream_not_proxied(self):
+        mock_stream = SimpleNamespace(_internal="secret", headers={})
+        wrapper = _AsyncLiteLLMStreamingInspectionWrapper(mock_stream, [], {})
+        with pytest.raises(AttributeError):
+            _ = wrapper._internal
+
+    @pytest.mark.asyncio
+    @patch("aidefense.runtime.agentsec.patchers.litellm._get_inspector")
+    async def test_async_iteration_and_final_inspection(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.ainspect_conversation = AsyncMock(
+            return_value=Decision.allow(reasons=[]),
+        )
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hi"))],
+        )
+
+        class AsyncStream:
+            def __init__(self):
+                self.headers = {}
+                self._chunks = [chunk]
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._chunks:
+                    raise StopAsyncIteration
+                return self._chunks.pop(0)
+
+        wrapper = _AsyncLiteLLMStreamingInspectionWrapper(
+            AsyncStream(),
+            [{"role": "user", "content": "Hello"}],
+            {},
+        )
+        chunks = [c async for c in wrapper]
+        assert len(chunks) == 1
+        mock_inspector.ainspect_conversation.assert_called()

--- a/aidefense/tests/agentsec/unit/test_litellm_patcher.py
+++ b/aidefense/tests/agentsec/unit/test_litellm_patcher.py
@@ -688,6 +688,37 @@ class TestLiteLLMStreamingInspectionWrapper:
         assert len(chunks) == 1
         assert mock_inspector.inspect_conversation.called
 
+    @patch("aidefense.runtime.agentsec.patchers.litellm._get_inspector")
+    def test_close_closes_stream_when_inspection_raises(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.block(reasons=["policy"])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "enforce"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="blocked"))],
+        )
+        mock_stream = MagicMock()
+        mock_stream.__iter__ = MagicMock(return_value=iter([chunk]))
+        mock_stream.headers = {}
+
+        wrapper = _LiteLLMStreamingInspectionWrapper(
+            mock_stream,
+            [{"role": "user", "content": "Hello"}],
+            {},
+        )
+        next(wrapper)
+
+        with pytest.raises(SecurityPolicyError):
+            wrapper.close()
+
+        mock_stream.close.assert_called_once()
+
 
 class TestAsyncLiteLLMStreamingInspectionWrapper:
     """Test async streaming wrapper attribute proxying."""
@@ -745,3 +776,50 @@ class TestAsyncLiteLLMStreamingInspectionWrapper:
         chunks = [c async for c in wrapper]
         assert len(chunks) == 1
         mock_inspector.ainspect_conversation.assert_called()
+
+    @pytest.mark.asyncio
+    @patch("aidefense.runtime.agentsec.patchers.litellm._get_inspector")
+    async def test_aclose_closes_stream_when_inspection_raises(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.ainspect_conversation = AsyncMock(
+            return_value=Decision.block(reasons=["policy"]),
+        )
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "enforce"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="blocked"))],
+        )
+
+        class AsyncStream:
+            def __init__(self):
+                self.headers = {}
+                self._chunks = [chunk]
+                self.close = MagicMock()
+                self.aclose = AsyncMock()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._chunks:
+                    raise StopAsyncIteration
+                return self._chunks.pop(0)
+
+        stream = AsyncStream()
+        wrapper = _AsyncLiteLLMStreamingInspectionWrapper(
+            stream,
+            [{"role": "user", "content": "Hello"}],
+            {},
+        )
+        await wrapper.__anext__()
+
+        with pytest.raises(SecurityPolicyError):
+            await wrapper.aclose()
+
+        stream.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary
- LiteLLM streaming calls failed when `protect(patch_clients=True)` wrapped the response because `_LiteLLMStreamingInspectionWrapper` did not proxy attributes like `.headers` to the underlying `CustomStreamWrapper`
- Added `__getattr__` delegation to both sync and async LiteLLM streaming wrappers, plus context-manager/close support aligned with the OpenAI streaming wrapper pattern

## Test plan
- [x] `poetry run pytest aidefense/tests/agentsec/unit/test_litellm_patcher.py -v` — 50 passed
- [x] New tests verify `.headers` and other attributes are proxied
- [x] New tests verify streaming iteration and final inspection still work
- [ ] Remove `@pytest.mark.xfail` from `test_agentsec_e2e_litellm_streaming` in `ai-defense-qa-api` after SDK release

## JIRA
https://cisco-sbg.atlassian.net/browse/AIFW-24950

Made with [Cursor](https://cursor.com)