### PR TITLE
Release 2.1.2 without obsolete PyPI uuid dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.2] - 2026-07-10
+
+### Added
+
+- **AIBOM high-level client** (`AiBomClient`) for analyze-and-submit workflows, with
+  optional `cisco-aidefense-sdk[aibom]` extra for local analysis support
+  ([#86](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/86), AIFW-19570).
+- **MCP registry endpoints** for MCP server management
+  ([#81](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/81), AIFW-19340).
+- **MCPScan model alignment** with the service proto definitions
+  ([#72](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/72),
+  re-landed in [#90](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/90)).
+- **`detected_pii` field** on inspection responses
+  ([#104](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/104)).
+- **Google ADK agentsec example** under `examples/agentsec/2-agent-frameworks/google-adk-agent/`
+  ([#103](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/103)).
+- **`UNSPECIFIED` connection status** handling in the connection event model enum
+  ([#106](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/106), AIFW-24958).
+
+### Changed
+
+- `Config` singleton now logs a warning when re-requested with different parameters
+  ([#102](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/102)).
+- Runtime version metadata (`aidefense/version.py`) and Sphinx docs (`docs/source/conf.py`)
+  are synced to the package version for accurate `User-Agent` reporting.
+- Updated `CONTRIBUTING.md`
+  ([#93](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/93)).
+- Agentsec example `requirements.txt` files no longer list the PyPI `uuid` package
+  ([#105](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/105)).
+
+### Fixed
+
+- `ValidateMCPServersRequest` now enforces required fields
+  ([#98](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/98), AIFW-21696).
+- `GetMCPServerScanReportRequest` now enforces `filter_options` as required
+  ([#100](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/100), AIFW-21697).
+- AIBOM module is optional at import time with regression coverage when `cisco-aibom` is
+  not installed (AIFW-19570).
+- AIBOM example and client handling for checksum validation and BOM status values
+  (AIFW-19570).
+
+### Removed
+
+- **Obsolete PyPI `uuid` dependency** — the SDK no longer declares a dependency on the
+  PyPI `uuid==1.30` package
+  ([#105](https://github.com/cisco-ai-defense/ai-defense-python-sdk/pull/105)).
+  That package is a Python 2-era shim with no wheel; installing it shadows Python 3's
+  stdlib `uuid` module. All SDK code uses only stdlib `uuid` APIs.
+
+### Upgrade guidance
+
+- Downstream packages should pin **`cisco-aidefense-sdk>=2.1.2`** to avoid transitively
+  installing PyPI `uuid` via older SDK releases.
+- After upgrading, verify `pip show uuid` returns nothing and
+  `python -c "import uuid; print(uuid.__file__)"` points to the stdlib module.
+
+[2.1.2]: https://github.com/cisco-ai-defense/ai-defense-python-sdk/compare/v2.1.1...v2.1.2

--- a/aidefense/version.py
+++ b/aidefense/version.py
@@ -14,4 +14,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version = "2.1.1"
+version = "2.1.2"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "AI Defense Python SDK"
 copyright = "2025, Cisco Systems, Inc."
 author = "Cisco Systems, Inc."
-release = "2.1.1"
+release = "2.1.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/examples/agentsec/2-agent-frameworks/crewai-agent/poetry.lock
+++ b/examples/agentsec/2-agent-frameworks/crewai-agent/poetry.lock
@@ -706,7 +706,7 @@ dev = ["chroma-hnswlib (==0.7.6)", "fastapi (>=0.115.9)", "opentelemetry-instrum
 
 [[package]]
 name = "cisco-aidefense-sdk"
-version = "2.1.1"
+version = "2.1.2"
 description = "Cisco AI Defense Python SDK"
 optional = false
 python-versions = "^3.9"
@@ -718,7 +718,9 @@ aiohttp = "^3.13.2"
 pydantic = "^2.12.5"
 requests = "^2.32.3"
 tenacity = "^9.1.2"
-uuid = "^1.30"
+
+[package.extras]
+aibom = ["cisco-aibom (>=0.4.0)"]
 
 [package.source]
 type = "directory"
@@ -5028,16 +5030,6 @@ brotli = ["brotli (>=1.2.0)", "brotlicffi (>=1.2.0.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0)"]
-
-[[package]]
-name = "uuid"
-version = "1.30"
-description = "UUID object and generation functions (Python 2.3 or higher)"
-optional = false
-python-versions = "*"
-files = [
-    {file = "uuid-1.30.tar.gz", hash = "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f"},
-]
 
 [[package]]
 name = "uv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cisco-aidefense-sdk"
-version = "2.1.1"
+version = "2.1.2"
 description = "Cisco AI Defense Python SDK"
 authors = [
     "Shiva Guntoju <shguntoj@cisco.com>",


### PR DESCRIPTION
## Summary
- Bumps `cisco-aidefense-sdk` to **2.1.2** so PyPI consumers can depend on a release that no longer declares the obsolete PyPI `uuid==1.30` package.
- The uuid removal itself landed in #105; this is the version bump needed for downstream packages (e.g. `langchain-cisco-aidefense`) to pin `>=2.1.2`.
- Syncs runtime (`aidefense/version.py`) and docs (`docs/source/conf.py`) version metadata to 2.1.2.

## Release Notes (v2.1.2)

### Fixed
- **Removed obsolete PyPI `uuid` dependency** — `cisco-aidefense-sdk` no longer declares a dependency on the PyPI `uuid==1.30` package (#105). That package is a Python 2-era shim with no wheel; installing it shadows Python 3's stdlib `uuid` module. All SDK code uses only stdlib `uuid` APIs (`uuid.uuid4()`, `uuid.UUID()`), so the PyPI dependency was unnecessary and harmful.
- **Runtime version metadata drift** — `aidefense/version.py` and Sphinx docs now report `2.1.2`, keeping the `Cisco-AI-Defense-Python-SDK/{version}` User-Agent aligned with the installed distribution.

### Upgrade guidance
- Downstream packages that transitively pulled in PyPI `uuid` via `cisco-aidefense-sdk` should pin **`cisco-aidefense-sdk>=2.1.2`**.
- After upgrading, verify `pip show uuid` returns nothing and `python -c "import uuid; print(uuid.__file__)"` points to the stdlib module.

### Full Changelog
https://github.com/cisco-ai-defense/ai-defense-python-sdk/compare/v2.1.1...v2.1.2

## Test plan
- [x] `poetry install` succeeds without the PyPI `uuid` package
- [x] `import uuid; uuid.uuid4()` resolves to stdlib
- [x] Existing unit tests pass

## JIRA
https://cisco-sbg.atlassian.net/browse/AIFW-25024