### PR TITLE
Proxy stream attributes in OpenAI streaming wrapper

### DIFF
--- a/aidefense/runtime/agentsec/patchers/openai.py
+++ b/aidefense/runtime/agentsec/patchers/openai.py
@@ -367,6 +367,11 @@ class StreamingInspectionWrapper:
         self._inspect_interval = 10  # Inspect every N chunks
         self._final_inspection_done = False
 
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
     def __enter__(self):
         return self
 
@@ -375,9 +380,11 @@ class StreamingInspectionWrapper:
         return False
 
     def close(self):
-        self._perform_final_inspection()
-        if hasattr(self._stream, "close"):
-            self._stream.close()
+        try:
+            self._perform_final_inspection()
+        finally:
+            if hasattr(self._stream, "close"):
+                self._stream.close()
     
     def __iter__(self):
         return self
@@ -472,6 +479,11 @@ class AsyncStreamingInspectionWrapper:
         self._inspect_interval = 10
         self._final_inspection_done = False
 
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
     async def __aenter__(self):
         return self
 
@@ -483,22 +495,28 @@ class AsyncStreamingInspectionWrapper:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._perform_final_inspection_sync()
-        if hasattr(self._stream, "close"):
-            self._stream.close()
+        try:
+            self._perform_final_inspection_sync()
+        finally:
+            if hasattr(self._stream, "close"):
+                self._stream.close()
         return False
 
     async def aclose(self):
-        await self._perform_final_inspection()
-        if hasattr(self._stream, "aclose"):
-            await self._stream.aclose()
-        elif hasattr(self._stream, "close"):
-            self._stream.close()
+        try:
+            await self._perform_final_inspection()
+        finally:
+            if hasattr(self._stream, "aclose"):
+                await self._stream.aclose()
+            elif hasattr(self._stream, "close"):
+                self._stream.close()
 
     def close(self):
-        self._perform_final_inspection_sync()
-        if hasattr(self._stream, "close"):
-            self._stream.close()
+        try:
+            self._perform_final_inspection_sync()
+        finally:
+            if hasattr(self._stream, "close"):
+                self._stream.close()
     
     def __aiter__(self):
         return self

--- a/aidefense/runtime/agentsec/patchers/openai.py
+++ b/aidefense/runtime/agentsec/patchers/openai.py
@@ -372,6 +372,11 @@ class StreamingInspectionWrapper:
             raise AttributeError(name)
         return getattr(self._stream, name)
 
+    def parse(self, *args, **kwargs):
+        """Return an inspection-wrapped stream from LegacyAPIResponse.parse()."""
+        parsed = self._stream.parse(*args, **kwargs)
+        return StreamingInspectionWrapper(parsed, self._messages, self._metadata)
+
     def __enter__(self):
         return self
 
@@ -483,6 +488,13 @@ class AsyncStreamingInspectionWrapper:
         if name.startswith("_"):
             raise AttributeError(name)
         return getattr(self._stream, name)
+
+    def parse(self, *args, **kwargs):
+        """Return an inspection-wrapped stream from LegacyAPIResponse.parse()."""
+        parsed = self._stream.parse(*args, **kwargs)
+        if hasattr(parsed, "__aiter__"):
+            return AsyncStreamingInspectionWrapper(parsed, self._messages, self._metadata)
+        return StreamingInspectionWrapper(parsed, self._messages, self._metadata)
 
     async def __aenter__(self):
         return self

--- a/aidefense/tests/agentsec/unit/test_azure_openai.py
+++ b/aidefense/tests/agentsec/unit/test_azure_openai.py
@@ -295,6 +295,7 @@ class TestAIFW24950LitellmAzureStreamingRawResponse:
         assert headers["x-ratelimit-remaining-requests"] == "99"
 
         parsed_stream = result.parse()
+        assert isinstance(parsed_stream, StreamingInspectionWrapper)
         assert list(parsed_stream) == [chunk]
 
     @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
@@ -372,7 +373,9 @@ class TestAIFW24950LitellmAzureStreamingRawResponse:
 
         assert isinstance(result, AsyncStreamingInspectionWrapper)
         assert dict(result.headers)["x-ms-region"] == "eastus"
-        assert list(result.parse()) == [chunk]
+        parsed = result.parse()
+        assert isinstance(parsed, StreamingInspectionWrapper)
+        assert list(parsed) == [chunk]
 
 
 

--- a/aidefense/tests/agentsec/unit/test_azure_openai.py
+++ b/aidefense/tests/agentsec/unit/test_azure_openai.py
@@ -17,11 +17,15 @@
 """Tests for Azure OpenAI coverage verification."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from aidefense.runtime.agentsec.patchers.openai import (
     patch_openai,
     _wrap_chat_completions_create,
+    _wrap_chat_completions_create_async,
+    StreamingInspectionWrapper,
+    AsyncStreamingInspectionWrapper,
 )
 from aidefense.runtime.agentsec.exceptions import SecurityPolicyError
 from aidefense.runtime.agentsec.decision import Decision
@@ -228,6 +232,147 @@ class TestAzureOpenAICoverage:
         assert result is mock_response
 
 
+class TestAIFW24950LitellmAzureStreamingRawResponse:
+    """Regression for AIFW-24950: LiteLLM Azure streaming via with_raw_response.create.
+
+    LiteLLM calls azure_client.chat.completions.with_raw_response.create(stream=True).
+    The patched Completions.create wraps the LegacyAPIResponse in StreamingInspectionWrapper.
+    LiteLLM then accesses raw_response.headers and raw_response.parse() before iterating.
+    """
+
+    @staticmethod
+    def _legacy_raw_streaming_response(chunks):
+        inner = iter(chunks)
+        return SimpleNamespace(
+            headers={
+                "x-ms-region": "eastus",
+                "x-ratelimit-remaining-requests": "99",
+            },
+            parse=lambda: inner,
+            close=MagicMock(),
+        )
+
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    @patch("aidefense.runtime.agentsec.patchers.openai.resolve_gateway_settings", return_value=None)
+    def test_wrap_streaming_exposes_headers_and_parse_for_litellm(
+        self, _gw, mock_get_inspector
+    ):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.allow(reasons=[])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta = MagicMock()
+        chunk.choices[0].delta.content = "Hello"
+
+        raw_response = self._legacy_raw_streaming_response([chunk])
+        mock_wrapped = MagicMock(return_value=raw_response)
+        mock_instance = MagicMock()
+
+        result = _wrap_chat_completions_create(
+            mock_wrapped,
+            mock_instance,
+            (),
+            {
+                "messages": [{"role": "user", "content": "Say hello"}],
+                "stream": True,
+                "model": "gpt-4",
+            },
+        )
+
+        assert isinstance(result, StreamingInspectionWrapper)
+
+        # LiteLLM extracts headers before parse()
+        headers = dict(result.headers)
+        assert headers["x-ms-region"] == "eastus"
+        assert headers["x-ratelimit-remaining-requests"] == "99"
+
+        parsed_stream = result.parse()
+        assert list(parsed_stream) == [chunk]
+
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    @patch("aidefense.runtime.agentsec.patchers.openai.resolve_gateway_settings", return_value=None)
+    def test_wrap_streaming_still_iterates_when_client_returns_plain_stream(
+        self, _gw, mock_get_inspector
+    ):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.allow(reasons=[])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk1 = MagicMock()
+        chunk1.choices = [MagicMock()]
+        chunk1.choices[0].delta = MagicMock()
+        chunk1.choices[0].delta.content = "Hello"
+
+        chunk2 = MagicMock()
+        chunk2.choices = [MagicMock()]
+        chunk2.choices[0].delta = MagicMock()
+        chunk2.choices[0].delta.content = " world!"
+
+        mock_wrapped = MagicMock(return_value=iter([chunk1, chunk2]))
+        mock_instance = MagicMock()
+
+        result = _wrap_chat_completions_create(
+            mock_wrapped,
+            mock_instance,
+            (),
+            {"messages": [{"role": "user", "content": "Say hello"}], "stream": True},
+        )
+
+        assert isinstance(result, StreamingInspectionWrapper)
+        assert len(list(result)) == 2
+
+    @pytest.mark.asyncio
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    @patch("aidefense.runtime.agentsec.patchers.openai.resolve_gateway_settings", return_value=None)
+    async def test_async_wrap_streaming_exposes_headers_and_parse_for_litellm(
+        self, _gw, mock_get_inspector
+    ):
+        mock_inspector = MagicMock()
+        mock_inspector.ainspect_conversation = AsyncMock(
+            return_value=Decision.allow(reasons=[]),
+        )
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hello"))],
+        )
+        raw_response = self._legacy_raw_streaming_response([chunk])
+        mock_wrapped = AsyncMock(return_value=raw_response)
+
+        result = await _wrap_chat_completions_create_async(
+            mock_wrapped,
+            MagicMock(),
+            (),
+            {
+                "messages": [{"role": "user", "content": "Say hello"}],
+                "stream": True,
+                "model": "gpt-4",
+            },
+        )
+
+        assert isinstance(result, AsyncStreamingInspectionWrapper)
+        assert dict(result.headers)["x-ms-region"] == "eastus"
+        assert list(result.parse()) == [chunk]
 
 
 

--- a/aidefense/tests/agentsec/unit/test_openai_patcher_extended.py
+++ b/aidefense/tests/agentsec/unit/test_openai_patcher_extended.py
@@ -28,7 +28,7 @@ _get_inspector, and patch_openai.
 import httpx
 import pytest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aidefense.runtime.agentsec.patchers.openai import (
     _detect_provider,
@@ -49,6 +49,7 @@ from aidefense.runtime.agentsec.patchers.openai import (
     _wrap_chat_completions_create,
     _wrap_responses_create,
     StreamingInspectionWrapper,
+    AsyncStreamingInspectionWrapper,
     patch_openai,
 )
 from aidefense.runtime.agentsec.exceptions import SecurityPolicyError
@@ -623,6 +624,122 @@ class TestStreamingInspectionWrapper:
         wrapper = StreamingInspectionWrapper(iter([chunk]), [], {})
         list(wrapper)
         mock_inspector.inspect_conversation.assert_not_called()
+
+    def test_proxies_headers_to_underlying_stream(self):
+        mock_stream = SimpleNamespace(
+            headers={"x-ratelimit-remaining-requests": "99", "x-ms-region": "eastus"},
+        )
+        wrapper = StreamingInspectionWrapper(mock_stream, [], {})
+        assert wrapper.headers == {
+            "x-ratelimit-remaining-requests": "99",
+            "x-ms-region": "eastus",
+        }
+
+    def test_litellm_azure_with_raw_response_pattern(self):
+        inner_stream = iter([SimpleNamespace(choices=[])])
+        raw_response = SimpleNamespace(
+            headers={"x-ms-region": "eastus"},
+            parse=lambda: inner_stream,
+        )
+        wrapper = StreamingInspectionWrapper(raw_response, [], {})
+        assert dict(wrapper.headers) == {"x-ms-region": "eastus"}
+        assert wrapper.parse() is inner_stream
+
+    def test_private_attribute_on_underlying_stream_not_proxied(self):
+        mock_stream = SimpleNamespace(_internal="secret", headers={})
+        wrapper = StreamingInspectionWrapper(mock_stream, [], {})
+        with pytest.raises(AttributeError):
+            _ = wrapper._internal
+
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    def test_close_closes_stream_when_inspection_raises(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.block(reasons=["policy"])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "enforce"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="blocked"))],
+        )
+        mock_stream = MagicMock()
+        mock_stream.__iter__ = MagicMock(return_value=iter([chunk]))
+        mock_stream.headers = {}
+
+        wrapper = StreamingInspectionWrapper(
+            mock_stream,
+            [{"role": "user", "content": "Hello"}],
+            {},
+        )
+        next(wrapper)
+
+        with pytest.raises(SecurityPolicyError):
+            wrapper.close()
+
+        mock_stream.close.assert_called_once()
+
+
+class TestAsyncStreamingInspectionWrapper:
+    def test_proxies_headers_to_underlying_stream(self):
+        mock_stream = SimpleNamespace(headers={"x-ms-region": "westus2"})
+        wrapper = AsyncStreamingInspectionWrapper(mock_stream, [], {})
+        assert wrapper.headers == {"x-ms-region": "westus2"}
+
+    def test_private_attribute_on_underlying_stream_not_proxied(self):
+        mock_stream = SimpleNamespace(_internal="secret", headers={})
+        wrapper = AsyncStreamingInspectionWrapper(mock_stream, [], {})
+        with pytest.raises(AttributeError):
+            _ = wrapper._internal
+
+    @pytest.mark.asyncio
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    async def test_aclose_closes_stream_when_inspection_raises(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.ainspect_conversation = AsyncMock(
+            return_value=Decision.block(reasons=["policy"]),
+        )
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "enforce"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="blocked"))],
+        )
+
+        class AsyncStream:
+            def __init__(self):
+                self.headers = {}
+                self._chunks = [chunk]
+                self.aclose = AsyncMock()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._chunks:
+                    raise StopAsyncIteration
+                return self._chunks.pop(0)
+
+        stream = AsyncStream()
+        wrapper = AsyncStreamingInspectionWrapper(
+            stream,
+            [{"role": "user", "content": "Hello"}],
+            {},
+        )
+        await wrapper.__anext__()
+
+        with pytest.raises(SecurityPolicyError):
+            await wrapper.aclose()
+
+        stream.aclose.assert_awaited_once()
 
 
 # ===========================================================================

--- a/aidefense/tests/agentsec/unit/test_openai_patcher_extended.py
+++ b/aidefense/tests/agentsec/unit/test_openai_patcher_extended.py
@@ -47,6 +47,7 @@ from aidefense.runtime.agentsec.patchers.openai import (
     _dict_to_openai_response,
     _create_stream_chunk_from_response,
     _wrap_chat_completions_create,
+    _wrap_chat_completions_create_async,
     _wrap_responses_create,
     StreamingInspectionWrapper,
     AsyncStreamingInspectionWrapper,
@@ -71,6 +72,20 @@ def reset_state():
     reset_registry()
     clear_inspection_context()
     openai_module._inspector = None
+
+
+def _legacy_raw_streaming_response(chunks, headers=None):
+    """Simulate openai LegacyAPIResponse from with_raw_response.create(stream=True)."""
+    inner = iter(chunks)
+    return SimpleNamespace(
+        headers=headers
+        or {
+            "x-ms-region": "eastus",
+            "content-type": "text/event-stream; charset=utf-8",
+        },
+        parse=lambda: inner,
+        close=MagicMock(),
+    )
 
 
 # ===========================================================================
@@ -689,6 +704,16 @@ class TestAsyncStreamingInspectionWrapper:
         wrapper = AsyncStreamingInspectionWrapper(mock_stream, [], {})
         assert wrapper.headers == {"x-ms-region": "westus2"}
 
+    def test_litellm_azure_with_raw_response_pattern(self):
+        inner_stream = iter([SimpleNamespace(choices=[])])
+        raw_response = SimpleNamespace(
+            headers={"x-ms-region": "westus2"},
+            parse=lambda: inner_stream,
+        )
+        wrapper = AsyncStreamingInspectionWrapper(raw_response, [], {})
+        assert dict(wrapper.headers) == {"x-ms-region": "westus2"}
+        assert wrapper.parse() is inner_stream
+
     def test_private_attribute_on_underlying_stream_not_proxied(self):
         mock_stream = SimpleNamespace(_internal="secret", headers={})
         wrapper = AsyncStreamingInspectionWrapper(mock_stream, [], {})
@@ -796,6 +821,117 @@ class TestWrapChatCompletionsCreate:
 
         with pytest.raises(SecurityPolicyError):
             _wrap_chat_completions_create(MagicMock(), SimpleNamespace(), (), {"model": "gpt-4", "messages": [{"role": "user", "content": "Hi"}]})
+
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    @patch("aidefense.runtime.agentsec.patchers.openai.resolve_gateway_settings", return_value=None)
+    def test_streaming_wrap_preserves_litellm_raw_response_access_aifw_24950(
+        self, _gw, mock_get_inspector
+    ):
+        """Regression for AIFW-24950: LiteLLM reads .headers/.parse() on wrapped raw response."""
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.allow(reasons=[])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hello"))],
+        )
+        raw_response = _legacy_raw_streaming_response([chunk])
+        mock_wrapped = MagicMock(return_value=raw_response)
+
+        result = _wrap_chat_completions_create(
+            mock_wrapped,
+            SimpleNamespace(),
+            (),
+            {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            },
+        )
+
+        assert isinstance(result, StreamingInspectionWrapper)
+        headers = dict(result.headers)
+        assert headers["x-ms-region"] == "eastus"
+        assert headers["content-type"] == "text/event-stream; charset=utf-8"
+        assert list(result.parse()) == [chunk]
+
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    @patch("aidefense.runtime.agentsec.patchers.openai.resolve_gateway_settings", return_value=None)
+    def test_streaming_wrap_plain_iterator_still_iterable(self, _gw, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.allow(reasons=[])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hi"))],
+        )
+        mock_wrapped = MagicMock(return_value=iter([chunk]))
+
+        result = _wrap_chat_completions_create(
+            mock_wrapped,
+            SimpleNamespace(),
+            (),
+            {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            },
+        )
+
+        assert isinstance(result, StreamingInspectionWrapper)
+        assert list(result) == [chunk]
+
+    @pytest.mark.asyncio
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    @patch("aidefense.runtime.agentsec.patchers.openai.resolve_gateway_settings", return_value=None)
+    async def test_async_streaming_wrap_preserves_litellm_raw_response_access_aifw_24950(
+        self, _gw, mock_get_inspector
+    ):
+        mock_inspector = MagicMock()
+        mock_inspector.ainspect_conversation = AsyncMock(
+            return_value=Decision.allow(reasons=[]),
+        )
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hello"))],
+        )
+        raw_response = _legacy_raw_streaming_response([chunk])
+        mock_wrapped = AsyncMock(return_value=raw_response)
+
+        result = await _wrap_chat_completions_create_async(
+            mock_wrapped,
+            SimpleNamespace(),
+            (),
+            {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            },
+        )
+
+        assert isinstance(result, AsyncStreamingInspectionWrapper)
+        headers = dict(result.headers)
+        assert headers["x-ms-region"] == "eastus"
+        assert list(result.parse()) == [chunk]
 
 
 # ===========================================================================

--- a/aidefense/tests/agentsec/unit/test_openai_patcher_extended.py
+++ b/aidefense/tests/agentsec/unit/test_openai_patcher_extended.py
@@ -651,14 +651,52 @@ class TestStreamingInspectionWrapper:
         }
 
     def test_litellm_azure_with_raw_response_pattern(self):
-        inner_stream = iter([SimpleNamespace(choices=[])])
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hi"))],
+        )
+        inner_stream = iter([chunk])
         raw_response = SimpleNamespace(
             headers={"x-ms-region": "eastus"},
             parse=lambda: inner_stream,
         )
-        wrapper = StreamingInspectionWrapper(raw_response, [], {})
+        wrapper = StreamingInspectionWrapper(
+            raw_response,
+            [{"role": "user", "content": "Hi"}],
+            {},
+        )
         assert dict(wrapper.headers) == {"x-ms-region": "eastus"}
-        assert wrapper.parse() is inner_stream
+        parsed = wrapper.parse()
+        assert isinstance(parsed, StreamingInspectionWrapper)
+        assert parsed is not wrapper
+        assert list(parsed) == [chunk]
+
+    @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
+    def test_parse_stream_runs_inspection(self, mock_get_inspector):
+        mock_inspector = MagicMock()
+        mock_inspector.inspect_conversation.return_value = Decision.allow(reasons=[])
+        mock_get_inspector.return_value = mock_inspector
+
+        _state.set_state(
+            initialized=True,
+            api_mode={"llm_defaults": {"fail_open": True}, "llm": {"mode": "monitor"}},
+        )
+        clear_inspection_context()
+
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hello"))],
+        )
+        raw_response = SimpleNamespace(
+            headers={},
+            parse=lambda: iter([chunk]),
+        )
+        wrapper = StreamingInspectionWrapper(
+            raw_response,
+            [{"role": "user", "content": "Hi"}],
+            {},
+        )
+
+        list(wrapper.parse())
+        mock_inspector.inspect_conversation.assert_called()
 
     def test_private_attribute_on_underlying_stream_not_proxied(self):
         mock_stream = SimpleNamespace(_internal="secret", headers={})
@@ -705,14 +743,23 @@ class TestAsyncStreamingInspectionWrapper:
         assert wrapper.headers == {"x-ms-region": "westus2"}
 
     def test_litellm_azure_with_raw_response_pattern(self):
-        inner_stream = iter([SimpleNamespace(choices=[])])
+        chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hi"))],
+        )
+        inner_stream = iter([chunk])
         raw_response = SimpleNamespace(
             headers={"x-ms-region": "westus2"},
             parse=lambda: inner_stream,
         )
-        wrapper = AsyncStreamingInspectionWrapper(raw_response, [], {})
+        wrapper = AsyncStreamingInspectionWrapper(
+            raw_response,
+            [{"role": "user", "content": "Hi"}],
+            {},
+        )
         assert dict(wrapper.headers) == {"x-ms-region": "westus2"}
-        assert wrapper.parse() is inner_stream
+        parsed = wrapper.parse()
+        assert isinstance(parsed, StreamingInspectionWrapper)
+        assert list(parsed) == [chunk]
 
     def test_private_attribute_on_underlying_stream_not_proxied(self):
         mock_stream = SimpleNamespace(_internal="secret", headers={})
@@ -859,7 +906,9 @@ class TestWrapChatCompletionsCreate:
         headers = dict(result.headers)
         assert headers["x-ms-region"] == "eastus"
         assert headers["content-type"] == "text/event-stream; charset=utf-8"
-        assert list(result.parse()) == [chunk]
+        parsed = result.parse()
+        assert isinstance(parsed, StreamingInspectionWrapper)
+        assert list(parsed) == [chunk]
 
     @patch("aidefense.runtime.agentsec.patchers.openai._get_inspector")
     @patch("aidefense.runtime.agentsec.patchers.openai.resolve_gateway_settings", return_value=None)
@@ -931,7 +980,9 @@ class TestWrapChatCompletionsCreate:
         assert isinstance(result, AsyncStreamingInspectionWrapper)
         headers = dict(result.headers)
         assert headers["x-ms-region"] == "eastus"
-        assert list(result.parse()) == [chunk]
+        parsed = result.parse()
+        assert isinstance(parsed, StreamingInspectionWrapper)
+        assert list(parsed) == [chunk]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Completes the fix for [AIFW-24950](https://cisco-sbg.atlassian.net/browse/AIFW-24950) after PR #109 only patched the LiteLLM wrapper
- LiteLLM Azure streaming uses `with_raw_response.create(stream=True)`, which hits the OpenAI patcher's `StreamingInspectionWrapper` before the LiteLLM wrapper is returned
- Added `__getattr__` delegation to `StreamingInspectionWrapper` and `AsyncStreamingInspectionWrapper` so `.headers`, `.parse()`, and other raw-response attributes proxy to the underlying stream
- Hardened `close()` / `aclose()` with `try/finally` so the provider stream is always released when final inspection raises

## Root cause
PR #109 fixed `_LiteLLMStreamingInspectionWrapper`, but the JIRA repro fails earlier with:
`StreamingInspectionWrapper object has no attribute 'headers'`

## Test plan
- [x] `pytest aidefense/tests/agentsec/unit/test_openai_patcher_extended.py -q` — 89 passed
- [x] New tests cover header proxying, LiteLLM Azure `with_raw_response` pattern, and close-on-enforce behavior
- [ ] Re-run `test_agentsec_e2e_litellm_streaming` with `--runxfail` in `ai-defense-qa-api`
- [ ] Remove `@pytest.mark.xfail` from QA test after E2E passes

## JIRA
https://cisco-sbg.atlassian.net/browse/AIFW-24950

Made with [Cursor](https://cursor.com)