### PR TITLE
Fix Poetry package declarations for validation SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Intended Audience :: Developers"
 ]
-packages = [
-    {include = "aidefense"},
-    {include = "ai_validation"},
-    {include = "ai_validation_service"},
-    {include = "ai_defense"},
-]
+packages = [{include = "aidefense"}]
 
 [tool.poetry.dependencies]
 aiohttp = "^3.13.2"


### PR DESCRIPTION
## Summary

- remove invalid top-level Poetry package declarations for `ai_validation`, `ai_validation_service`, and `ai_defense`
- retain `aidefense` as the package root, which recursively includes the generated validation subpackages

## Root cause

The validation modules are located under `aidefense/pydantic/validation/`, but `pyproject.toml` declared them as top-level package directories. `poetry install --extras aibom` therefore failed with `ai_validation does not contain any element` before tests could run.

## Impact

This restores dependency installation and package building for the 2.1.3 release branch without changing runtime behavior.

## Validation

- `poetry check` — passed with existing deprecation warnings
- `poetry install --extras aibom` — passed
- `poetry build` — passed; generated validation modules are present in the wheel
- `git diff --check` — passed
- `poetry run pytest` — 596 passed, 8 skipped, 3 pre-existing failures in `aidefense/tests/test_config.py` related to singleton warning behavior removed by the base branch
