### PR TITLE
[AIFW-23555]: Fix stale package entries breaking poetry install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ classifiers = [
 ]
 packages = [
     {include = "aidefense"},
-    {include = "ai_validation"},
-    {include = "ai_validation_service"},
-    {include = "ai_defense"},
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary

- Remove stale `ai_validation`, `ai_validation_service`, and `ai_defense` top-level package entries from `pyproject.toml`
- These directories don't exist — the generated pydantic models live under `aidefense/pydantic/validation/`, already covered by the `aidefense` include
- The stale entries cause `poetry install` to fail with `ai_validation does not contain any element`

## Test plan

- [x] `poetry install` succeeds
- [x] `poetry run pytest` — 580 passed, 11 skipped, 6 pre-existing failures (unrelated: 3 config warning tests, 3 missing optional cloud provider deps)